### PR TITLE
Add arkworks dependencies features avaliable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,6 @@ merlin = {version = "3.0", default-features = false}
 rand_core = {version="0.6", default-features=false}
 itertools = {version = "0.10.1", default-features = false}
 hashbrown = {version = "0.11.2", default-features=false, features = ["ahash"]}
-rayon = {version = "1.3", optional = true}
-cfg-if = "1.0"
 num-traits = "0.2.14"
 
 [dev-dependencies]
@@ -44,12 +42,20 @@ ark-ed-on-bls12-381 = "0.3"
 rand = "0.8.0"
 
 [features]
-default = ["std"]
-std = [
+default = [
     "rand_core/std",
     "itertools/default",
-    "hashbrown/default",
-    "rayon"
+    "parallel",
+    "asm"
+    ]
+parallel = [
+    "ark-ff/parallel",
+    "ark-poly/parallel",
+    "ark-ec/parallel",
+    "ark-poly-commit/parallel"
+]
+asm = [
+    "ark-ff/asm"
 ]
 trace = []
 trace-print = ["trace"]

--- a/README.md
+++ b/README.md
@@ -155,18 +155,16 @@ fn main() {
 ### Features
 
 This crate includes a variety of features which will briefly be explained below:
-- `alloc`: Enables the usage of an allocator and with it the capability of performing `Proof` constructions and
-  verifications. Without this feature it **IS NOT** possible to prove or verify anything.
-  Its absence only makes `ark-plonk` export certain fixed-size data structures such as `Proof` which can be useful in no_std envoirments where we don't have allocators either.
-- `std`: Enables `std` usage as well as `rayon` parallelisation in some proving and verifying ops.
+- `parallel`: Enables `rayon` and other parallelisation primitives to be used and speed up some of the algorithms used
+by the crate and it's dependencies.
+- `asm`: Enables inline-assembly implementations for some of the internal algorithms and primitives used by the `arkworks` dependencies of the crate.
 - `trace`: Enables the Circuit debugger tooling. This is essentially the capability of using the
-  `StandardComposer::check_circuit_satisfied` function. The function will output information about each circuit gate until
-  one of the gates does not satisfy the equation, or there are no more gates. If there is an unsatisfied gate
-  equation, the function will panic and return the gate number.
+`StandardComposer::check_circuit_satisfied` function. The function will output information about each circuit gate until one of the gates does not satisfy the equation, or there are no more gates. If there is an unsatisfied gate
+equation, the function will panic and return the gate number.
 - `trace-print`: Goes a step further than `trace` and prints each `gate` component data, giving a clear overview of all the
-  values which make up the circuit that we're constructing.
-  __The recommended method is to derive the std output, and the std error, and then place them in text file
-    which can be used to efficiently analyse the gates.__
+values which make up the circuit that we're constructing.
+__The recommended method is to derive the std output, and the std error, and then place them in text file
+  which can be used to efficiently analyse the gates.__
 
 
 
@@ -176,7 +174,7 @@ There are two main types of documentation in this repository:
 
 - **Crate documentation**. This provides info about all of the functions that the library provides, as well
   as the documentation regarding the data structures that it exports. To check this, please feel free to go to
-  the [documentation page](https://docs.rs/dusk-plonk/) or run `make doc` or `make doc-internal`.
+  the [documentation page](https://docs.rs/ark-plonk/) or run `make doc` or `make doc-internal`.
 
 - **Notes**. This is a specific subset of documentation which explains the key mathematical concepts
   of PLONK and how they work with mathematical demonstrations. To check it, run `make doc` and open the resulting docs,

--- a/src/permutation/permutation.rs
+++ b/src/permutation/permutation.rs
@@ -644,8 +644,7 @@ impl<F: PrimeField> Permutation<F> {
         w + beta * sigma + gamma
     }
 
-    // Uses a rayon multizip to allow more code flexibility while remaining
-    // parallelizable. This can be adapted into a general product argument
+    // This can be adapted into a general product argument
     // for any number of wires, with specific formulas defined
     // in the numerator_irreducible and denominator_irreducible functions
     pub(crate) fn compute_permutation_poly(
@@ -755,7 +754,7 @@ impl<F: PrimeField> Permutation<F> {
 mod test {
     use super::*;
     use crate::{constraint_system::StandardComposer, util};
-    use ark_bls12_381::{Bls12_381, Fr as BlsScalar, FrParameters};
+    use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
     use ark_ed_on_bls12_381::{
         EdwardsParameters as JubjubParameters,
         EdwardsProjective as JubjubProjective,


### PR DESCRIPTION
`parallel` and `asm` featues of all dependencies are now avaliable to
use and also enabled by default.

Resolves: #10