### PR TITLE
Remove ProjectiveCurve from standard composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ use core::marker::PhantomData;
 
 use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
 use ark_ec::twisted_edwards_extended::GroupAffine;
-use ark_ec::{AffineCurve, PairingEngine, ProjectiveCurve, TEModelParameters};
+use ark_ec::{AffineCurve, PairingEngine, , TEModelParameters};
 use ark_ed_on_bls12_381::{
     EdwardsAffine as JubjubAffine, EdwardsParameters as JubjubParameters,
     EdwardsProjective as JubjubProjective, Fr as JubjubScalar,

--- a/src/constraint_system/arithmetic.rs
+++ b/src/constraint_system/arithmetic.rs
@@ -6,14 +6,13 @@
 
 use crate::constraint_system::StandardComposer;
 use crate::constraint_system::Variable;
-use ark_ec::{PairingEngine, ProjectiveCurve, TEModelParameters};
+use ark_ec::{PairingEngine, TEModelParameters};
 use num_traits::{One, Zero};
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > StandardComposer<E, T, P>
+    > StandardComposer<E, P>
 {
     /// Adds a width-3 add gate to the circuit, linking the addition of the
     /// provided inputs, scaled by the selector coefficients with the output
@@ -316,7 +315,6 @@ mod arithmetic_gates_tests {
     use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
     use ark_ed_on_bls12_381::{
         EdwardsParameters as JubjubParameters,
-        EdwardsProjective as JubjubProjective,
     };
     use num_traits::{One, Zero};
 
@@ -325,7 +323,6 @@ mod arithmetic_gates_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let var_one = composer.add_input(BlsScalar::one());
@@ -365,7 +362,6 @@ mod arithmetic_gates_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 // Verify that (4+5+5) * (6+7+7) = 280
@@ -420,7 +416,6 @@ mod arithmetic_gates_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let zero = composer.zero_var();
@@ -444,7 +439,6 @@ mod arithmetic_gates_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 // Verify that (4+5+5) * (6+7+7) + (8*9) = 352
@@ -494,7 +488,6 @@ mod arithmetic_gates_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 // Verify that (5+5) * (6+7) != 117

--- a/src/constraint_system/boolean.rs
+++ b/src/constraint_system/boolean.rs
@@ -6,14 +6,13 @@
 
 use crate::constraint_system::StandardComposer;
 use crate::constraint_system::Variable;
-use ark_ec::{PairingEngine, ProjectiveCurve, TEModelParameters};
+use ark_ec::{PairingEngine, TEModelParameters};
 use num_traits::{One, Zero};
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > StandardComposer<E, T, P>
+    > StandardComposer<E, P>
 {
     /// Adds a boolean constraint (also known as binary constraint) where
     /// the gate eq. will enforce that the [`Variable`] received is either `0`
@@ -58,7 +57,6 @@ mod boolean_gates_tests {
     use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
     use ark_ed_on_bls12_381::{
         EdwardsParameters as JubjubParameters,
-        EdwardsProjective as JubjubProjective,
     };
     use num_traits::One;
     #[test]
@@ -66,7 +64,6 @@ mod boolean_gates_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let zero = composer.zero_var();
@@ -85,7 +82,6 @@ mod boolean_gates_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let zero = composer.add_input(BlsScalar::from(5));

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -22,7 +22,6 @@ use crate::constraint_system::Variable;
 use crate::permutation::Permutation;
 use ark_ec::models::TEModelParameters;
 use ark_ec::PairingEngine;
-use ark_ec::ProjectiveCurve;
 use core::marker::PhantomData;
 use hashbrown::HashMap;
 use num_traits::{One, Zero};
@@ -57,7 +56,6 @@ use std::collections::BTreeMap;
 #[derive(Debug)]
 pub struct StandardComposer<
     E: PairingEngine,
-    T: ProjectiveCurve<BaseField = E::Fr>,
     P: TEModelParameters<BaseField = E::Fr>,
 > {
     /// Number of arithmetic gates in the circuit
@@ -115,14 +113,12 @@ pub struct StandardComposer<
 
     // Markers
     _marker: PhantomData<P>,
-    _marker2: PhantomData<T>,
 }
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > StandardComposer<E, T, P>
+    > StandardComposer<E, P>
 {
     /// Returns the number of gates in the circuit
     pub fn circuit_size(&self) -> usize {
@@ -155,9 +151,8 @@ impl<
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > Default for StandardComposer<E, T, P>
+    > Default for StandardComposer<E, P>
 {
     fn default() -> Self {
         Self::new()
@@ -166,9 +161,8 @@ impl<
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > StandardComposer<E, T, P>
+    > StandardComposer<E, P>
 {
     /// Generates a new empty `StandardComposer` with all of it's fields
     /// set to hold an initial capacity of 0.
@@ -178,7 +172,7 @@ impl<
     /// The usage of this may cause lots of re-allocations since the `Composer`
     /// holds `Vec` for every polynomial, and these will need to be re-allocated
     /// each time the circuit grows considerably.
-    pub fn new() -> StandardComposer<E, T, P> {
+    pub fn new() -> StandardComposer<E, P> {
         StandardComposer::with_expected_size(0)
     }
 
@@ -226,7 +220,6 @@ impl<
             perm: Permutation::new(),
 
             _marker: PhantomData,
-            _marker2: PhantomData,
         };
 
         // Reserve the first variable to be zero
@@ -654,9 +647,8 @@ mod general_composer_tests {
     use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
     use ark_ed_on_bls12_381::{
         EdwardsParameters as JubjubParameters,
-        EdwardsProjective as JubjubProjective,
     };
-    use ark_ed_on_bls12_381::{EdwardsParameters, EdwardsProjective};
+    use ark_ed_on_bls12_381::{EdwardsParameters,};
     use ark_poly::univariate::DensePolynomial;
     use ark_poly_commit::kzg10;
     use ark_poly_commit::kzg10::Powers;
@@ -672,7 +664,6 @@ mod general_composer_tests {
     fn test_initial_circuit_size() {
         let composer: StandardComposer<
             Bls12_381,
-            EdwardsProjective,
             EdwardsParameters,
         > = StandardComposer::new();
         // Circuit size is n+3 because
@@ -693,7 +684,6 @@ mod general_composer_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 // do nothing except add the dummy constraints
@@ -708,7 +698,6 @@ mod general_composer_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let bit_1 = composer.add_input(BlsScalar::one());
@@ -742,7 +731,7 @@ mod general_composer_tests {
         .unwrap();
 
         // Create a prover struct
-        let mut prover: Prover<Bls12_381, JubjubProjective, JubjubParameters> =
+        let mut prover: Prover<Bls12_381, JubjubParameters> =
             Prover::new(b"demo");
 
         // Add gadgets
@@ -781,7 +770,6 @@ mod general_composer_tests {
         //
         let mut verifier: Verifier<
             Bls12_381,
-            JubjubProjective,
             JubjubParameters,
         > = Verifier::new(b"demo");
 

--- a/src/constraint_system/ecc/curve_addition/fixed_base_gate.rs
+++ b/src/constraint_system/ecc/curve_addition/fixed_base_gate.rs
@@ -7,14 +7,14 @@
 use crate::constraint_system::StandardComposer;
 use crate::constraint_system::Variable;
 use ark_ec::models::TEModelParameters;
-use ark_ec::{PairingEngine, ProjectiveCurve};
+use ark_ec::{PairingEngine};
 use core::marker::PhantomData;
 use num_traits::{One, Zero};
 
 #[derive(Debug, Clone, Copy)]
 /// Contains all of the components needed to verify that a bit scalar
 /// multiplication was computed correctly
-pub struct WnafRound<E: PairingEngine, T: ProjectiveCurve<BaseField = E::Fr>> {
+pub struct WnafRound<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>> {
     /// This is the accumulated x coordinate point that we wish to add (so
     /// far.. depends on where you are in the scalar mul) it is linked to
     /// the wnaf entry, so must not be revealed
@@ -32,21 +32,20 @@ pub struct WnafRound<E: PairingEngine, T: ProjectiveCurve<BaseField = E::Fr>> {
     pub xy_alpha: Variable,
     /// This is the possible x co-ordinate of the wnaf point we are going to
     /// add Actual x-co-ordinate = b_i * x_\beta
-    pub x_beta: T::BaseField,
+    pub x_beta: P::BaseField,
     /// This is the possible y co-ordinate of the wnaf point we are going to
     /// add Actual y coordinate = (b_i)^2 [y_\beta -1] + 1
-    pub y_beta: T::BaseField,
+    pub y_beta: P::BaseField,
     /// This is the multiplication of x_\beta * y_\beta
-    pub xy_beta: T::BaseField,
+    pub xy_beta: P::BaseField,
     _marker0: PhantomData<E>,
-    _marker1: PhantomData<T>,
+    _marker1: PhantomData<P>,
 }
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > StandardComposer<E, T, P>
+    > StandardComposer<E, P>
 {
     /// Generates a new structure for preparing a WNAF ROUND
     pub fn new_wnaf(
@@ -54,10 +53,10 @@ impl<
         acc_y: Variable,
         accumulated_bit: Variable,
         xy_alpha: Variable,
-        x_beta: T::BaseField,
-        y_beta: T::BaseField,
-        xy_beta: T::BaseField,
-    ) -> WnafRound<E, T> {
+        x_beta: P::BaseField,
+        y_beta: P::BaseField,
+        xy_beta: P::BaseField,
+    ) -> WnafRound<E, P> {
         WnafRound {
             acc_x,
             acc_y,
@@ -71,7 +70,7 @@ impl<
         }
     }
     /// Fixed group addition of a jubjub point
-    pub(crate) fn fixed_group_add(&mut self, wnaf_round: WnafRound<E, T>) {
+    pub(crate) fn fixed_group_add(&mut self, wnaf_round: WnafRound<E, P>) {
         self.w_l.push(wnaf_round.acc_x);
         self.w_r.push(wnaf_round.acc_y);
         self.w_o.push(wnaf_round.xy_alpha);

--- a/src/constraint_system/ecc/curve_addition/variable_base_gate.rs
+++ b/src/constraint_system/ecc/curve_addition/variable_base_gate.rs
@@ -8,14 +8,13 @@ use crate::constraint_system::ecc::Point;
 use crate::constraint_system::StandardComposer;
 use ark_ec::models::twisted_edwards_extended::GroupAffine;
 use ark_ec::models::TEModelParameters;
-use ark_ec::{PairingEngine, ProjectiveCurve};
+use ark_ec::{PairingEngine};
 use num_traits::{One, Zero};
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > StandardComposer<E, T, P>
+    > StandardComposer<E, P>
 {
     /// Adds two curve points together using a curve addition gate
     /// Note that since the points are not fixed the generator is not a part of
@@ -23,9 +22,9 @@ impl<
     /// width of 4.
     pub fn point_addition_gate(
         &mut self,
-        point_a: Point<E, T, P>,
-        point_b: Point<E, T, P>,
-    ) -> Point<E, T, P> {
+        point_a: Point<E, P>,
+        point_b: Point<E, P>,
+    ) -> Point<E, P> {
         // In order to verify that two points were correctly added
         // without going over a degree 4 polynomial, we will need
         // x_1, y_1, x_2, y_2
@@ -88,7 +87,7 @@ impl<
         );
         self.n += 1;
 
-        Point::<E, T, P>::new(x_3, y_3)
+        Point::<E, P>::new(x_3, y_3)
     }
 }
 
@@ -99,7 +98,6 @@ mod variable_base_gate_tests {
     use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
     use ark_ed_on_bls12_381::{
         EdwardsAffine as JubjubAffine, EdwardsParameters as JubjubParameters,
-        EdwardsProjective as JubjubProjective,
     };
     use ark_ff::Field;
     use num_traits::{One, Zero};
@@ -109,12 +107,11 @@ mod variable_base_gate_tests {
     pub fn classical_point_addition(
         composer: &mut StandardComposer<
             Bls12_381,
-            JubjubProjective,
             JubjubParameters,
         >,
-        point_a: Point<Bls12_381, JubjubProjective, JubjubParameters>,
-        point_b: Point<Bls12_381, JubjubProjective, JubjubParameters>,
-    ) -> Point<Bls12_381, JubjubProjective, JubjubParameters> {
+        point_a: Point<Bls12_381, JubjubParameters>,
+        point_b: Point<Bls12_381, JubjubParameters>,
+    ) -> Point<Bls12_381, JubjubParameters> {
         let x1 = point_a.x;
         let y1 = point_a.y;
 

--- a/src/constraint_system/ecc/scalar_mul/fixed_base.rs
+++ b/src/constraint_system/ecc/scalar_mul/fixed_base.rs
@@ -33,9 +33,8 @@ where
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > StandardComposer<E, T, P>
+    > StandardComposer<E, P>
 {
     /// Adds an elliptic curve Scalar multiplication gate to the circuit
     /// description.
@@ -49,7 +48,7 @@ impl<
         &mut self,
         jubjub_scalar: Variable,
         base_point: GroupAffine<P>,
-    ) -> Point<E, T, P> {
+    ) -> Point<E, P> {
         let num_bits =
             <P::BaseField as PrimeField>::Params::MODULUS_BITS as usize;
         // compute 2^iG
@@ -133,7 +132,7 @@ impl<
 
             let xy_beta = x_beta * y_beta;
 
-            let wnaf_round = StandardComposer::<E, T, P>::new_wnaf(
+            let wnaf_round = StandardComposer::<E, P>::new_wnaf(
                 acc_x,
                 acc_y,
                 accumulated_bit,
@@ -170,7 +169,7 @@ impl<
         // input jubjub scalar
         self.assert_equal(last_accumulated_bit, jubjub_scalar);
 
-        Point::<E, T, P>::new(acc_x, acc_y)
+        Point::<E, P>::new(acc_x, acc_y)
     }
 }
 
@@ -183,7 +182,6 @@ mod tests {
     use ark_ec::{group::Group, AffineCurve};
     use ark_ed_on_bls12_381::{
         EdwardsAffine as JubjubAffine, EdwardsParameters as JubjubParameters,
-        EdwardsProjective as JubjubProjective,
     };
     use ark_ff::PrimeField;
     use num_traits::Zero;
@@ -193,7 +191,6 @@ mod tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let bls_scalar = BlsScalar::from_le_bytes_mod_order(&[
@@ -226,7 +223,6 @@ mod tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let bls_scalar = BlsScalar::zero();
@@ -252,7 +248,6 @@ mod tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let bls_scalar = BlsScalar::from(100u64);
@@ -283,7 +278,6 @@ mod tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let (x, y) = JubjubParameters::AFFINE_GENERATOR_COEFFS;
@@ -304,7 +298,6 @@ mod tests {
                 let var_point_a_y = composer.add_input(affine_point_a.y);
                 let point_a = Point::<
                     Bls12_381,
-                    JubjubProjective,
                     JubjubParameters,
                 >::new(
                     var_point_a_x, var_point_a_y
@@ -313,7 +306,6 @@ mod tests {
                 let var_point_b_y = composer.add_input(affine_point_b.y);
                 let point_b = Point::<
                     Bls12_381,
-                    JubjubProjective,
                     JubjubParameters,
                 >::new(
                     var_point_b_x, var_point_b_y
@@ -336,7 +328,6 @@ mod tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let (x, y) = JubjubParameters::AFFINE_GENERATOR_COEFFS;
@@ -394,7 +385,6 @@ mod tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let (x, y) = JubjubParameters::AFFINE_GENERATOR_COEFFS;

--- a/src/constraint_system/ecc/scalar_mul/variable_base.rs
+++ b/src/constraint_system/ecc/scalar_mul/variable_base.rs
@@ -7,15 +7,14 @@
 use crate::constraint_system::ecc::Point;
 use crate::constraint_system::{variable::Variable, StandardComposer};
 use ark_ec::models::TEModelParameters;
-use ark_ec::{PairingEngine, ProjectiveCurve};
+use ark_ec::{PairingEngine};
 use ark_ff::{BigInteger, Field, FpParameters, PrimeField};
 use num_traits::{One, Zero};
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > StandardComposer<E, T, P>
+    > StandardComposer<E, P>
 {
     /// Adds a variable-base scalar multiplication to the circuit description.
     ///
@@ -26,8 +25,8 @@ impl<
     pub fn variable_base_scalar_mul(
         &mut self,
         curve_var: Variable,
-        point: Point<E, T, P>,
-    ) -> Point<E, T, P> {
+        point: Point<E, P>,
+    ) -> Point<E, P> {
         // Turn scalar into bits
         let raw_bls_scalar = *self
             .variables
@@ -105,7 +104,6 @@ mod tests {
     use ark_ec::AffineCurve;
     use ark_ed_on_bls12_381::{
         EdwardsAffine as JubjubAffine, EdwardsParameters as JubjubParameters,
-        EdwardsProjective as JubjubProjective,
     };
     use ark_ff::PrimeField;
     #[test]
@@ -113,7 +111,6 @@ mod tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let scalar = BlsScalar::from_le_bytes_mod_order(&[

--- a/src/constraint_system/helper.rs
+++ b/src/constraint_system/helper.rs
@@ -38,11 +38,10 @@ pub(crate) fn slow_multibase_mul_single_scalar<E: PairingEngine>(
 /// Adds dummy constraints using arithmetic gates
 pub(crate) fn dummy_gadget<
     E: PairingEngine,
-    T: ProjectiveCurve<BaseField = E::Fr>,
     P: TEModelParameters<BaseField = E::Fr>,
 >(
     n: usize,
-    composer: &mut StandardComposer<E, T, P>,
+    composer: &mut StandardComposer<E, P>,
 ) {
     let one = E::Fr::one();
 
@@ -63,10 +62,9 @@ pub(crate) fn dummy_gadget<
 /// tests whether it passes an end-to-end test
 pub(crate) fn gadget_tester<
     E: PairingEngine,
-    T: ProjectiveCurve<BaseField = E::Fr>,
     P: TEModelParameters<BaseField = E::Fr>,
 >(
-    gadget: fn(composer: &mut StandardComposer<E, T, P>),
+    gadget: fn(composer: &mut StandardComposer<E, P>),
     n: usize,
 ) -> Result<(), Error> {
     // Common View

--- a/src/constraint_system/logic.rs
+++ b/src/constraint_system/logic.rs
@@ -6,15 +6,14 @@
 
 use crate::constraint_system::StandardComposer;
 use crate::constraint_system::{Variable, WireData};
-use ark_ec::{PairingEngine, ProjectiveCurve, TEModelParameters};
+use ark_ec::{PairingEngine, TEModelParameters};
 use ark_ff::{BigInteger, PrimeField};
 use num_traits::{One, Zero};
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > StandardComposer<E, T, P>
+    > StandardComposer<E, P>
 {
     /// Performs a logical AND or XOR op between the inputs provided for the
     /// specified number of bits.
@@ -349,7 +348,6 @@ mod logic_gate_tests {
     use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
     use ark_ed_on_bls12_381::{
         EdwardsParameters as JubjubParameters,
-        EdwardsProjective as JubjubProjective,
     };
 
     #[test]
@@ -358,7 +356,6 @@ mod logic_gate_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let witness_a = composer.add_input(BlsScalar::from(500u64));
@@ -379,7 +376,6 @@ mod logic_gate_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let witness_a = composer.add_input(BlsScalar::from(469u64));
@@ -401,7 +397,6 @@ mod logic_gate_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let witness_a = composer.add_input(BlsScalar::from(139u64));
@@ -422,7 +417,6 @@ mod logic_gate_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let witness_a = composer.add_input(BlsScalar::from(256u64));
@@ -447,7 +441,6 @@ mod logic_gate_tests {
         let _ = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let witness_a = composer.add_input(BlsScalar::from(500u64));

--- a/src/constraint_system/range.rs
+++ b/src/constraint_system/range.rs
@@ -6,15 +6,14 @@
 
 use crate::constraint_system::StandardComposer;
 use crate::constraint_system::{Variable, WireData};
-use ark_ec::{PairingEngine, ProjectiveCurve, TEModelParameters};
+use ark_ec::{PairingEngine, TEModelParameters};
 use ark_ff::{BigInteger, PrimeField};
 use num_traits::{One, Zero};
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > StandardComposer<E, T, P>
+    > StandardComposer<E, P>
 {
     /// Adds a range-constraint gate that checks and constrains a
     /// [`Variable`] to be inside of the range \[0,num_bits\].
@@ -28,7 +27,7 @@ impl<
     pub fn range_gate(&mut self, witness: Variable, num_bits: usize) {
         // Adds `variable` into the appropriate witness position
         // based on the accumulator number a_i
-        let add_wire = |composer: &mut StandardComposer<E, T, P>,
+        let add_wire = |composer: &mut StandardComposer<E, P>,
                         i: usize,
                         variable: Variable| {
             // Since four quads can fit into one gate, the gate index does
@@ -203,7 +202,6 @@ mod range_gate_tests {
     use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
     use ark_ed_on_bls12_381::{
         EdwardsParameters as JubjubParameters,
-        EdwardsProjective as JubjubProjective,
     };
 
     #[test]
@@ -212,7 +210,6 @@ mod range_gate_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let witness = composer
@@ -227,7 +224,6 @@ mod range_gate_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let witness =
@@ -242,7 +238,6 @@ mod range_gate_tests {
         let res = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let witness =
@@ -261,7 +256,6 @@ mod range_gate_tests {
         let _ok = gadget_tester(
             |composer: &mut StandardComposer<
                 Bls12_381,
-                JubjubProjective,
                 JubjubParameters,
             >| {
                 let witness = composer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,10 +44,10 @@ pub mod prelude;
 pub mod proof_system;
 mod transcript;
 
-use ark_ec::{PairingEngine, ProjectiveCurve, TEModelParameters};
+use ark_ec::{PairingEngine, TEModelParameters};
 // Currently unused
 pub(crate) trait SCParams:
-    TEModelParameters + PairingEngine + ProjectiveCurve
+    TEModelParameters + PairingEngine
 {
 }
 

--- a/src/permutation/permutation.rs
+++ b/src/permutation/permutation.rs
@@ -755,10 +755,9 @@ impl<F: PrimeField> Permutation<F> {
 mod test {
     use super::*;
     use crate::{constraint_system::StandardComposer, util};
-    use ark_bls12_381::{Bls12_381, Fr as BlsScalar, FrParameters};
+    use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
     use ark_ed_on_bls12_381::{
         EdwardsParameters as JubjubParameters,
-        EdwardsProjective as JubjubProjective,
     };
     use ark_ff::fields::FftParameters;
     use ark_ff::Field;
@@ -773,7 +772,6 @@ mod test {
     fn test_multizip_permutation_poly() {
         let mut cs: StandardComposer<
             Bls12_381,
-            JubjubProjective,
             JubjubParameters,
         > = StandardComposer::with_expected_size(4);
         let x1 = cs.add_input(BlsScalar::new(

--- a/src/proof_system/preprocess.rs
+++ b/src/proof_system/preprocess.rs
@@ -10,7 +10,7 @@ use crate::constraint_system::StandardComposer;
 use crate::error::Error;
 use crate::proof_system::{widget, ProverKey};
 use crate::transcript::TranscriptWrapper;
-use ark_ec::{PairingEngine, ProjectiveCurve, TEModelParameters};
+use ark_ec::{PairingEngine, TEModelParameters};
 use ark_ff::PrimeField;
 use ark_poly::polynomial::univariate::DensePolynomial;
 use ark_poly::{EvaluationDomain, Evaluations, GeneralEvaluationDomain};
@@ -40,9 +40,8 @@ pub(crate) struct SelectorPolynomials<F: PrimeField> {
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > StandardComposer<E, T, P>
+    > StandardComposer<E, P>
 {
     /// Pads the circuit to the next power of two.
     ///
@@ -538,7 +537,6 @@ mod test {
     use ark_bls12_381::Bls12_381;
     use ark_ed_on_bls12_381::{
         EdwardsParameters as JubjubParameters,
-        EdwardsProjective as JubjubProjective,
     };
     #[test]
     /// Tests that the circuit gets padded to the correct length
@@ -546,7 +544,6 @@ mod test {
     fn test_pad() {
         let mut composer: StandardComposer<
             Bls12_381,
-            JubjubProjective,
             JubjubParameters,
         > = StandardComposer::new();
         dummy_gadget(100, &mut composer);

--- a/src/proof_system/prover.rs
+++ b/src/proof_system/prover.rs
@@ -13,7 +13,7 @@ use crate::{
     transcript::{TranscriptProtocol, TranscriptWrapper},
     util,
 };
-use ark_ec::{PairingEngine, ProjectiveCurve, TEModelParameters};
+use ark_ec::{PairingEngine, TEModelParameters};
 use ark_ff::Field;
 use ark_poly::{
     univariate::DensePolynomial, EvaluationDomain, GeneralEvaluationDomain,
@@ -28,13 +28,12 @@ use num_traits::Zero;
 #[allow(missing_debug_implementations)]
 pub struct Prover<
     E: PairingEngine,
-    T: ProjectiveCurve<BaseField = E::Fr>,
     P: TEModelParameters<BaseField = E::Fr>,
 > {
     /// ProverKey which is used to create proofs about a specific PLONK circuit
     pub prover_key: Option<ProverKey<E::Fr, P>>,
 
-    pub(crate) cs: StandardComposer<E, T, P>,
+    pub(crate) cs: StandardComposer<E, P>,
     /// Store the messages exchanged during the preprocessing stage
     /// This is copied each time, we make a proof
     pub preprocessed_transcript: TranscriptWrapper<E>,
@@ -42,12 +41,11 @@ pub struct Prover<
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > Prover<E, T, P>
+    > Prover<E, P>
 {
     /// Returns a mutable copy of the underlying [`StandardComposer`].
-    pub fn mut_cs(&mut self) -> &mut StandardComposer<E, T, P> {
+    pub fn mut_cs(&mut self) -> &mut StandardComposer<E, P> {
         &mut self.cs
     }
 
@@ -66,23 +64,21 @@ impl<
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > Default for Prover<E, T, P>
+    > Default for Prover<E, P>
 {
-    fn default() -> Prover<E, T, P> {
+    fn default() -> Prover<E, P> {
         Prover::new(b"plonk")
     }
 }
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > Prover<E, T, P>
+    > Prover<E, P>
 {
     /// Creates a new `Prover` instance.
-    pub fn new(label: &'static [u8]) -> Prover<E, T, P> {
+    pub fn new(label: &'static [u8]) -> Prover<E, P> {
         Prover {
             prover_key: None,
             cs: StandardComposer::new(),
@@ -94,7 +90,7 @@ impl<
     pub fn with_expected_size(
         label: &'static [u8],
         size: usize,
-    ) -> Prover<E, T, P> {
+    ) -> Prover<E, P> {
         Prover {
             prover_key: None,
             cs: StandardComposer::with_expected_size(size),

--- a/src/proof_system/verifier.rs
+++ b/src/proof_system/verifier.rs
@@ -9,20 +9,19 @@ use crate::error::Error;
 use crate::proof_system::widget::VerifierKey as PlonkVerifierKey;
 use crate::proof_system::Proof;
 use crate::transcript::TranscriptWrapper;
-use ark_ec::{PairingEngine, ProjectiveCurve, TEModelParameters};
+use ark_ec::{PairingEngine, TEModelParameters};
 use ark_poly_commit::kzg10::{Powers, VerifierKey};
 
 /// Abstraction structure designed verify [`Proof`]s.
 #[allow(missing_debug_implementations)]
 pub struct Verifier<
     E: PairingEngine,
-    T: ProjectiveCurve<BaseField = E::Fr>,
     P: TEModelParameters<BaseField = E::Fr>,
 > {
     /// VerificationKey which is used to verify a specific PLONK circuit
     pub verifier_key: Option<PlonkVerifierKey<E, P>>,
 
-    pub(crate) cs: StandardComposer<E, T, P>,
+    pub(crate) cs: StandardComposer<E, P>,
     /// Store the messages exchanged during the preprocessing stage
     /// This is copied each time, we make a proof, so that we can use the same
     /// verifier to Verify multiple proofs from the same circuit. If this
@@ -33,23 +32,21 @@ pub struct Verifier<
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > Default for Verifier<E, T, P>
+    > Default for Verifier<E, P>
 {
-    fn default() -> Verifier<E, T, P> {
+    fn default() -> Verifier<E, P> {
         Verifier::new(b"plonk")
     }
 }
 
 impl<
         E: PairingEngine,
-        T: ProjectiveCurve<BaseField = E::Fr>,
         P: TEModelParameters<BaseField = E::Fr>,
-    > Verifier<E, T, P>
+    > Verifier<E, P>
 {
     /// Creates a new `Verifier` instance.
-    pub fn new(label: &'static [u8]) -> Verifier<E, T, P> {
+    pub fn new(label: &'static [u8]) -> Verifier<E, P> {
         Verifier {
             verifier_key: None,
             cs: StandardComposer::new(),
@@ -61,7 +58,7 @@ impl<
     pub fn with_expected_size(
         label: &'static [u8],
         size: usize,
-    ) -> Verifier<E, T, P> {
+    ) -> Verifier<E, P> {
         Verifier {
             verifier_key: None,
             cs: StandardComposer::with_expected_size(size),
@@ -75,7 +72,7 @@ impl<
     }
 
     /// Returns a mutable copy of the underlying composer.
-    pub fn mut_cs(&mut self) -> &mut StandardComposer<E, T, P> {
+    pub fn mut_cs(&mut self) -> &mut StandardComposer<E, P> {
         &mut self.cs
     }
 


### PR DESCRIPTION
Removed  `ProjectiveCurve` from the standard composer and a few other structures that did not require it. 

Closes #13 