### PR TITLE
Docs examples

### DIFF
--- a/src/constraint_system/helper.rs
+++ b/src/constraint_system/helper.rs
@@ -7,7 +7,7 @@
 use super::StandardComposer;
 use crate::error::Error;
 use crate::proof_system::{Prover, Verifier};
-use ark_ec::{PairingEngine, ProjectiveCurve, TEModelParameters};
+use ark_ec::{PairingEngine, TEModelParameters};
 use ark_poly::univariate::DensePolynomial;
 use ark_poly_commit::kzg10::{self, Powers, KZG10};
 use ark_poly_commit::sonic_pc::SonicKZG10;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,6 @@ pub mod prelude;
 pub mod proof_system;
 mod transcript;
 
-use ark_ec::{PairingEngine, TEModelParameters};
-// Currently unused
-pub(crate) trait SCParams:
-    TEModelParameters + PairingEngine
-{
-}
 #[doc = include_str!("../docs/notes-intro.md")]
 pub mod notes {
     #[doc = include_str!("../docs/notes-commitments.md")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,12 @@ pub mod prelude;
 pub mod proof_system;
 mod transcript;
 
+use ark_ec::{PairingEngine, TEModelParameters};
+// Currently unused
+pub(crate) trait SCParams:
+    TEModelParameters + PairingEngine
+{
+}
 #[doc = include_str!("../docs/notes-intro.md")]
 pub mod notes {
     #[doc = include_str!("../docs/notes-commitments.md")]


### PR DESCRIPTION
Resolve doc examples of `circuit.rs`. Also, ad-hoc traits of `IntoPubInputs` are made public, so that they can be called out of the library. 