### PR TITLE
Fix CI missing `uses` parameter in Run clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           override: false
-      - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --verbose --release --workspace --examples --tests --all-features -- -D warnings
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
@@ -99,3 +94,23 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  clippy:
+    if: github.event.pull_request.draft == false
+
+    name: Clippy lint checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: clippy
+      - name: Run clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --verbose --release --workspace --examples --tests --all-features -- -D warnings
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           override: false
       - name: Run clippy
+        uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: --verbose --release --workspace --examples --tests --all-features -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI checks
 on: 
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
+env: 
+  RUSTFLAGS: "-D warnings"
 
 ## `actions-rs/toolchain@v1` overwrite set to false so that 
 ## `rust-toolchain` is always used and the only source of truth.
@@ -28,7 +30,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --release --workspace --all-features -- -D warnings
+          args: --verbose --release --workspace --all-features
 
   build:
     if: github.event.pull_request.draft == false
@@ -105,12 +107,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
-          override: true
+          override: false
           components: clippy
       - name: Run clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --verbose --release --workspace --examples --tests --all-features -- -D warnings
-
+          args: --verbose --release --workspace --examples --tests --all-features

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -22,14 +22,12 @@ use crate::constraint_system::Variable;
 use crate::permutation::Permutation;
 use ark_ec::models::TEModelParameters;
 use ark_ec::PairingEngine;
+#[cfg(feature = "trace")]
 use ark_ff::{BigInteger, PrimeField};
 use core::marker::PhantomData;
 use hashbrown::HashMap;
 use num_traits::{One, Zero};
 use std::collections::BTreeMap;
-
-#[cfg(feature = "trace")]
-use ark_ff::{BigInteger, PrimeField};
 
 /// The StandardComposer is the circuit-builder tool that the `dusk-plonk`
 /// repository provides so that circuit descriptions can be written, stored and


### PR DESCRIPTION
In #38 an error was introduced in the CI so that it wasn't possible to
run them since they were panicking before starting.

- Edit the CI config and move clippy to a sepparated job.
- Edit the CI config and add global RUSTFLAGS env var.
- Edit the CI config and use better toolchain config.

Resolves: #39

Co-authored-by: Brandon H. Gomes <bhgomes@pm.me>