### PR TITLE
Arithmetic gate simplification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,16 @@
 name: CI checks
 
-on: 
+on:
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
-env: 
+  push:
+    branches:
+      - master
+
+env:
   RUSTFLAGS: "-D warnings"
 
-## `actions-rs/toolchain@v1` overwrite set to false so that 
+## `actions-rs/toolchain@v1` overwrite set to false so that
 ## `rust-toolchain` is always used and the only source of truth.
 
 jobs:
@@ -82,7 +86,7 @@ jobs:
 
   fmt:
     if: github.event.pull_request.draft == false
-    
+
     name: Rustfmt
     timeout-minutes: 30
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PLONK
-![Build Status](https://github.com/rust-zkp/ZK-Garage/workflows/Continuous%20integration/badge.svg)
+[![CI checks](https://github.com/ZK-Garage/plonk/actions/workflows/ci.yml/badge.svg)](https://github.com/ZK-Garage/plonk/actions/workflows/ci.yml)
 [![Repository](https://img.shields.io/badge/github-plonk-blueviolet?logo=github)](https://github.com/ZK-Garage/plonk)
 [![Documentation](https://img.shields.io/badge/docs-plonk-blue?logo=rust)](https://docs.rs/plonk/)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PLONK
-![Build Status](https://github.com/rust-zkp/ark-plonk/workflows/Continuous%20integration/badge.svg)
-[![Repository](https://img.shields.io/badge/github-plonk-blueviolet?logo=github)](https://github.com/rust-zkp/ark-plonk)
+![Build Status](https://github.com/rust-zkp/ZK-Garage/workflows/Continuous%20integration/badge.svg)
+[![Repository](https://img.shields.io/badge/github-plonk-blueviolet?logo=github)](https://github.com/ZK-Garage/plonk)
 [![Documentation](https://img.shields.io/badge/docs-plonk-blue?logo=rust)](https://docs.rs/plonk/)
 
 

--- a/README.md
+++ b/README.md
@@ -12,24 +12,7 @@ Initial implementation created by [Kev](https://github.com/kevaundray), [Carlos]
 Redesigned by the [rust zkp](https://github.com/rust-zkp) team to have a backend which is compatible with the [arkworks](https://github.com/arkworks-rs) suite. This allows us to leverage the multitude of curves
 and optimised algebra present in various arkworks repositories.
 
-## Usage
-```rust
-use core::marker::PhantomData;
-use ark_bls12_381::{Bls12_381, Fr as BlsScalar};
-use ark_ec::twisted_edwards_extended::GroupAffine;
-use ark_ec::{AffineCurve, PairingEngine, TEModelParameters};
-use ark_ed_on_bls12_381::{
-    EdwardsAffine as JubjubAffine, EdwardsParameters as JubjubParameters,
-    EdwardsProjective as JubjubProjective, Fr as JubjubScalar,
-};
-use ark_ff::{BigInteger, PrimeField};
-use ark_plonk::circuit::{self, Circuit, PublicInputValue};
-use ark_plonk::prelude::*;
-use num_traits::{One, Zero};
-use rand_core::OsRng;
-
-
-### Features
+## Features
 
 This crate includes a variety of features which will briefly be explained below:
 - `parallel`: Enables `rayon` and other parallelisation primitives to be used and speed up some of the algorithms used
@@ -111,16 +94,10 @@ Verify 2^18 = 262144 gates/18 time:   [6.7577 ms 6.8124 ms 6.8925 ms]
 - Initial [implementation](https://github.com/kobigurk/plonk/tree/kobigurk/port_to_zexe) of PLONK with arkworks backend was done years before this lib existed by Kobi Gurkan
 
 ## Licensing
-
-
-This software is distributed under the 
-terms of both the MIT license and 
-theApache License (Version 2.0). Please 
-see [LICENSE-MIT](https://github.com/rust-zkp/ark-plonk/blob/master/LICENSE-MIT) 
-and [LICENSE-APACHE](https://github.com/rust-zkp/ark-plonk/blob/master/LICENSE-APACHE) 
-for further info.
+This software is distributed under the terms of both the MIT license and 
+the Apache License (Version 2.0). Please see [LICENSE-MIT](https://github.com/rust-zkp/ark-plonk/blob/master/LICENSE-MIT) 
+and [LICENSE-APACHE](https://github.com/rust-zkp/ark-plonk/blob/master/LICENSE-APACHE) for further info.
 
 ## Contributing
-
 - If you want to contribute to this repository/project please, check [CONTRIBUTING.md](https://github.com/rust-zkp/ark-plonk/blob/master/CONTRIBUTING.md)
 - If you want to report a bug or request a new feature addition, please open an issue on this repository.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ _This is a pure Rust implementation of the PLONK zk proving system_
 
 ## About
 Initial implementation created by [Kev](https://github.com/kevaundray), [Carlos](https://github.com/CPerezz) and [Luke](https://github.com/LukePearson1) at Dusk Network.
-Redesigned by the [rust zkp](https://github.com/rust-zkp) team to have a backend which is compatible with the [arkworks](https://github.com/arkworks-rs) suite. This allows us to leverage the multitude of curves
-and optimised algebra present in various arkworks repositories.
+Redesigned by the [ZK-Garage](https://github.com/ZK-Garage) team to have a backend which is compatible with the [arkworks](https://github.com/arkworks-rs) suite. This allows us to leverage the multitude of curves and optimised algebra present in various arkworks repositories.
+
+Please, if you're interested on collaborating or contributing, you can join our Discord here: <https://discord.gg/XWJdhVf37F>
 
 ## Features
 
@@ -95,9 +96,11 @@ Verify 2^18 = 262144 gates/18 time:   [6.7577 ms 6.8124 ms 6.8925 ms]
 
 ## Licensing
 This software is distributed under the terms of both the MIT license and 
-the Apache License (Version 2.0). Please see [LICENSE-MIT](https://github.com/rust-zkp/ark-plonk/blob/master/LICENSE-MIT) 
-and [LICENSE-APACHE](https://github.com/rust-zkp/ark-plonk/blob/master/LICENSE-APACHE) for further info.
+the Apache License (Version 2.0). 
+Please see [LICENSE-MIT](https://github.com/ZK-Garage/plonk/blob/master/LICENSE-MIT) 
+and [LICENSE-APACHE](https://github.com/ZK-Garage/plonk/blob/master/LICENSE-APACHE) for further info.
 
 ## Contributing
-- If you want to contribute to this repository/project please, check [CONTRIBUTING.md](https://github.com/rust-zkp/ark-plonk/blob/master/CONTRIBUTING.md)
+- If you want to contribute to this repository/project please, check [CONTRIBUTING.md](https://github.com/ZK-Garage/plonk/blob/master/CONTRIBUTING.md)
 - If you want to report a bug or request a new feature addition, please open an issue on this repository.
+

--- a/src/constraint_system/arithmetic.rs
+++ b/src/constraint_system/arithmetic.rs
@@ -13,423 +13,150 @@ use crate::constraint_system::Variable;
 use ark_ec::{PairingEngine, TEModelParameters};
 use num_traits::{One, Zero};
 
-impl<E, P> StandardComposer<E, P>
-where
-    E: PairingEngine,
-    P: TEModelParameters<BaseField = E::Fr>,
+#[derive(Debug, Clone, Copy)]
+pub struct ArithmeticGate<E: PairingEngine> {
+    pub(crate) witness: Option<(Variable, Variable, Option<Variable>)>,
+    pub(crate) fan_in_3: Option<(E::Fr, Variable)>,
+    pub(crate) mul_selector: E::Fr,
+    pub(crate) add_selectors: (E::Fr, E::Fr),
+    pub(crate) out_selector: E::Fr,
+    pub(crate) const_selector: E::Fr,
+    pub(crate) pi: E::Fr,
+}
+
+impl<E: PairingEngine> Default for ArithmeticGate<E> {
+    fn default() -> Self {
+        Self {
+            witness: None,
+            fan_in_3: None,
+            mul_selector: E::Fr::zero(),
+            add_selectors: (E::Fr::zero(), E::Fr::zero()),
+            out_selector: -E::Fr::one(),
+            const_selector: E::Fr::zero(),
+            pi: E::Fr::zero(),
+        }
+    }
+}
+
+impl<E: PairingEngine> ArithmeticGate<E> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn witness(
+        &mut self,
+        witness: (Variable, Variable, Option<Variable>),
+    ) -> &mut Self {
+        self.witness = Some(witness);
+        self
+    }
+
+    pub fn fan_in_3(&mut self, sel_and_wit: (E::Fr, Variable)) -> &mut Self {
+        self.fan_in_3 = Some(sel_and_wit);
+        self
+    }
+
+    pub fn mul(&mut self, q_m: E::Fr) -> &mut Self {
+        self.mul_selector = q_m;
+        self
+    }
+
+    pub fn add(&mut self, selectors: (E::Fr, E::Fr)) -> &mut Self {
+        self.add_selectors = selectors;
+        self
+    }
+
+    pub fn out(&mut self, q_o: E::Fr) -> &mut Self {
+        self.out_selector = q_o;
+        self
+    }
+
+    pub fn const_sel(&mut self, q_c: E::Fr) -> &mut Self {
+        self.const_selector = q_c;
+        self
+    }
+
+    pub fn pi(&mut self, pi: E::Fr) -> &mut Self {
+        self.pi = pi;
+        self
+    }
+
+    pub fn build(&mut self) -> Self {
+        *self
+    }
+}
+
+impl<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>>
+    StandardComposer<E, P>
 {
-    /// Adds a width-3 add gate to the circuit, linking the addition of the
-    /// provided inputs, scaled by the selector coefficients with the output
-    /// provided.
-    pub fn add_gate(
-        &mut self,
-        a: Variable,
-        b: Variable,
-        c: Variable,
-        q_l: E::Fr,
-        q_r: E::Fr,
-        q_o: E::Fr,
-        q_c: E::Fr,
-        pi: Option<E::Fr>,
-    ) -> Variable {
-        self.big_add_gate(a, b, c, None, q_l, q_r, q_o, E::Fr::zero(), q_c, pi)
-    }
+    /// Function used to generate any arithmetic gate with fan-in-2 or fan-in-3.
+    pub fn arithmetic_gate<F>(&mut self, func: F) -> Variable
+    where
+        F: FnOnce(&mut ArithmeticGate<E>) -> &mut ArithmeticGate<E>,
+    {
+        let gate = {
+            let mut gate = ArithmeticGate::<E>::new();
+            func(&mut gate).build()
+        };
+        if gate.witness.is_none() {
+            panic!("Missing left and right wire witnesses")
+        }
 
-    /// Adds a width-4 add gate to the circuit and it's corresponding
-    /// constraint.
-    ///
-    /// This type of gate is usually used when we need to have
-    /// the largest amount of performance and the minimum circuit-size
-    /// possible. Since it allows the end-user to set every selector coefficient
-    /// as scaling value on the gate eq.
-    pub fn big_add_gate(
-        &mut self,
-        a: Variable,
-        b: Variable,
-        c: Variable,
-        d: Option<Variable>,
-        q_l: E::Fr,
-        q_r: E::Fr,
-        q_o: E::Fr,
-        q_4: E::Fr,
-        q_c: E::Fr,
-        pi: Option<E::Fr>,
-    ) -> Variable {
-        // Check if advice wire has a value
-        let d = match d {
-            Some(var) => var,
-            None => self.zero_var,
+        let (w4, q4) = if gate.fan_in_3.is_none() {
+            self.w_4.push(self.zero_var);
+            self.q_4.push(E::Fr::zero());
+            (self.zero_var, E::Fr::zero())
+        } else {
+            let (q4, w4) = gate.fan_in_3.unwrap();
+            self.w_4.push(w4);
+            self.q_4.push(q4);
+            (w4, q4)
         };
 
-        self.w_l.push(a);
-        self.w_r.push(b);
-        self.w_o.push(c);
-        self.w_4.push(d);
-
-        // For an add gate, q_m is zero
-        self.q_m.push(E::Fr::zero());
+        let gate_witness = gate.witness.unwrap();
+        self.q_l.push(gate.add_selectors.0);
+        self.q_r.push(gate.add_selectors.1);
 
         // Add selector vectors
-        self.q_l.push(q_l);
-        self.q_r.push(q_r);
-        self.q_o.push(q_o);
-        self.q_c.push(q_c);
-        self.q_4.push(q_4);
+        self.q_m.push(gate.mul_selector);
+        self.q_o.push(gate.out_selector);
+        self.q_c.push(gate.const_selector);
+
         self.q_arith.push(E::Fr::one());
         self.q_range.push(E::Fr::zero());
         self.q_logic.push(E::Fr::zero());
         self.q_fixed_group_add.push(E::Fr::zero());
         self.q_variable_group_add.push(E::Fr::zero());
 
-        if let Some(pi) = pi {
-            assert!(self.public_inputs_sparse_store.insert(self.n, pi).is_none(),"The invariant of already having a PI inserted for this position should never exist");
-        }
+        assert!(self
+            .public_inputs_sparse_store
+            .insert(self.n, gate.pi)
+            .is_none());
 
-        self.perm.add_variables_to_map(a, b, c, d, self.n);
-
-        self.n += 1;
-
-        c
-    }
-    /// Adds a width-3 mul gate to the circuit linking the product of the
-    /// provided inputs scaled by the selector coefficient `q_m` with the output
-    /// provided scaled by `q_o`.
-    ///
-    /// Note that this gate requires to provide the actual result of the gate
-    /// (output wire) since it will just add a `mul constraint` to the circuit.
-    pub fn mul_gate(
-        &mut self,
-        a: Variable,
-        b: Variable,
-        c: Variable,
-        q_m: E::Fr,
-        q_o: E::Fr,
-        q_c: E::Fr,
-        pi: Option<E::Fr>,
-    ) -> Variable {
-        self.big_mul_gate(a, b, c, None, q_m, q_o, q_c, E::Fr::zero(), pi)
-    }
-
-    /// Adds a width-4 `big_mul_gate` with the left, right and fourth inputs
-    /// and it's scaling factors, computing & returning the output (result)
-    /// `Variable` and adding the corresponding mul constraint.
-    ///
-    /// This type of gate is usually used when we need to have
-    /// the largest amount of performance and the minimum circuit-size
-    /// possible. Since it allows the end-user to setup all of the selector
-    /// coefficients.
-    ///
-    /// Forces `q_m * (a * b) + q_4 * d + q_c + q_o * c = 0`
-    // XXX: Maybe make these tuples instead of individual field?
-    pub fn big_mul_gate(
-        &mut self,
-        a: Variable,
-        b: Variable,
-        c: Variable,
-        d: Option<Variable>,
-        q_m: E::Fr,
-        q_o: E::Fr,
-        q_c: E::Fr,
-        q_4: E::Fr,
-        pi: Option<E::Fr>,
-    ) -> Variable {
-        // Check if advice wire has a value
-        let d = match d {
-            Some(var) => var,
-            None => self.zero_var,
-        };
-
-        self.w_l.push(a);
-        self.w_r.push(b);
+        let c = gate_witness.2.unwrap_or_else(|| {
+            self.add_input(
+                ((gate.mul_selector
+                    * (self.variables[&gate_witness.0]
+                        * self.variables[&gate_witness.1]))
+                    + gate.add_selectors.0 * self.variables[&gate_witness.0]
+                    + gate.add_selectors.1 * self.variables[&gate_witness.1]
+                    + gate.const_selector
+                    + q4 * self.variables[&w4]
+                    + gate.pi)
+                    * gate.out_selector,
+            )
+        });
         self.w_o.push(c);
-        self.w_4.push(d);
-
-        // For a mul gate q_L and q_R is zero
-        self.q_l.push(E::Fr::zero());
-        self.q_r.push(E::Fr::zero());
-
-        // Add selector vectors
-        self.q_m.push(q_m);
-        self.q_o.push(q_o);
-        self.q_c.push(q_c);
-        self.q_4.push(q_4);
-        self.q_arith.push(E::Fr::one());
-
-        self.q_range.push(E::Fr::zero());
-        self.q_logic.push(E::Fr::zero());
-        self.q_fixed_group_add.push(E::Fr::zero());
-        self.q_variable_group_add.push(E::Fr::zero());
-
-        if let Some(pi) = pi {
-            assert!(
-                self.public_inputs_sparse_store.insert(self.n, pi).is_none(),"The invariant of already having a PI inserted for this position should never exist"
-            );
-        }
-
-        self.perm.add_variables_to_map(a, b, c, d, self.n);
-
-        self.n += 1;
-
-        c
-    }
-
-    /// This gates turns on all the selctor polynomials to give users,
-    /// in some situations, the ability to use the extra selector for
-    /// more variables into additions.
-    ///
-    /// This type of gate is usually used when we need to have
-    /// the largest amount of performance and the minimum circuit-size
-    /// possible. Since it allows the end-user to setup all of the selector
-    /// coefficients.
-    ///
-    /// Equation: `(a*b)*q_m + a*q_l + b*q_r + d*q_4 + q_c + PI + q_o * c = 0`.
-    /// `d` will be set to zero if not provided.
-    ///
-    /// ### Returns
-    /// `c`
-    pub fn big_arith_gate(
-        &mut self,
-        a: Variable,
-        b: Variable,
-        c: Variable,
-        d: Option<Variable>,
-        q_m: E::Fr,
-        q_l: E::Fr,
-        q_r: E::Fr,
-        q_o: E::Fr,
-        q_c: E::Fr,
-        q_4: E::Fr,
-        pi: Option<E::Fr>,
-    ) -> Variable {
-        // Check if advice wire has a value
-        let d = match d {
-            Some(var) => var,
-            None => self.zero_var,
-        };
-
-        self.w_l.push(a);
-        self.w_r.push(b);
-        self.w_o.push(c);
-        self.w_4.push(d);
-
-        // Add selector vectors
-        self.q_m.push(q_m);
-        self.q_o.push(q_o);
-        self.q_c.push(q_c);
-        self.q_4.push(q_4);
-        self.q_l.push(q_l);
-        self.q_r.push(q_r);
-        self.q_arith.push(E::Fr::one());
-
-        self.q_range.push(E::Fr::zero());
-        self.q_logic.push(E::Fr::zero());
-        self.q_fixed_group_add.push(E::Fr::zero());
-        self.q_variable_group_add.push(E::Fr::zero());
-
-        if let Some(pi) = pi {
-            assert!(
-                self.public_inputs_sparse_store.insert(self.n, pi).is_none(),"The invariant of already having a PI inserted for this position should never exist"
-            );
-        }
-
-        self.perm.add_variables_to_map(a, b, c, d, self.n);
-
-        self.n += 1;
-
-        c
-    }
-
-    /// Adds a [`StandardComposer::big_add_gate`] with the left and right
-    /// inputs and it's scaling factors, computing & returning the output
-    /// (result) [`Variable`], and adding the corresponding addition
-    /// constraint.
-    ///
-    /// This type of gate is usually used when we don't need to have
-    /// the largest amount of performance as well as the minimum circuit-size
-    /// possible. Since it defaults some of the selector coeffs = 0 in order
-    /// to reduce the verbosity and complexity.
-    ///
-    /// Forces `q_l * w_l + q_r * w_r + q_c + PI = w_o(computed by the gate)`.
-    pub fn add(
-        &mut self,
-        q_l_a: (E::Fr, Variable),
-        q_r_b: (E::Fr, Variable),
-        q_c: E::Fr,
-        pi: Option<E::Fr>,
-    ) -> Variable {
-        self.big_add(q_l_a, q_r_b, None, q_c, pi)
-    }
-
-    /// Adds a [`StandardComposer::big_add_gate`] with the left, right and
-    /// fourth inputs and it's scaling factors, computing & returning the
-    /// output (result) [`Variable`] and adding the corresponding addition
-    /// constraint.
-    ///
-    /// This type of gate is usually used when we don't need to have
-    /// the largest amount of performance and the minimum circuit-size
-    /// possible. Since it defaults some of the selector coeffs = 0 in order
-    /// to reduce the verbosity and complexity.
-    ///
-    /// Forces `q_l * w_l + q_r * w_r + q_4 * w_4 + q_c + PI = w_o(computed by
-    /// the gate)`.
-    pub fn big_add(
-        &mut self,
-        q_l_a: (E::Fr, Variable),
-        q_r_b: (E::Fr, Variable),
-        q_4_d: Option<(E::Fr, Variable)>,
-        q_c: E::Fr,
-        pi: Option<E::Fr>,
-    ) -> Variable {
-        // Check if advice wire is available
-        let (q_4, d) = match q_4_d {
-            Some((q_4, var)) => (q_4, var),
-            None => (E::Fr::zero(), self.zero_var),
-        };
-
-        let (q_l, a) = q_l_a;
-        let (q_r, b) = q_r_b;
-
-        let q_o = -E::Fr::one();
-
-        // Compute the output wire
-        let a_eval = self.variables[&a];
-        let b_eval = self.variables[&b];
-        let d_eval = self.variables[&d];
-        let c_eval = (q_l * a_eval)
-            + (q_r * b_eval)
-            + (q_4 * d_eval)
-            + q_c
-            + pi.unwrap_or_default();
-        let c = self.add_input(c_eval);
-
-        self.big_add_gate(a, b, c, Some(d), q_l, q_r, q_o, q_4, q_c, pi)
-    }
-
-    /// Adds a [`StandardComposer::big_mul_gate`] with the left, right
-    /// and fourth inputs and it's scaling factors, computing & returning
-    /// the output (result) [`Variable`] and adding the corresponding mul
-    /// constraint.
-    ///
-    /// This type of gate is usually used when we don't need to have
-    /// the largest amount of performance and the minimum circuit-size
-    /// possible. Since it defaults some of the selector coeffs = 0 in order
-    /// to reduce the verbosity and complexity.
-    ///
-    /// Forces `q_m * (w_l * w_r) + w_4 * q_4 + q_c + PI = w_o(computed by the
-    /// gate)`.
-    ///
-    /// `{w_l, w_r, w_4} = {a, b, d}`
-    pub fn mul(
-        &mut self,
-        q_m: E::Fr,
-        a: Variable,
-        b: Variable,
-        q_c: E::Fr,
-        pi: Option<E::Fr>,
-    ) -> Variable {
-        self.big_mul(q_m, a, b, None, q_c, pi)
-    }
-
-    /// Adds a width-4 [`StandardComposer::big_mul_gate`] with the left, right
-    /// and fourth inputs and it's scaling factors, computing & returning
-    /// the output (result) [`Variable`] and adding the corresponding mul
-    /// constraint.
-    ///
-    /// This type of gate is usually used when we don't need to have
-    /// the largest amount of performance and the minimum circuit-size
-    /// possible. Since it defaults some of the selector coeffs = 0 in order
-    /// to reduce the verbosity and complexity.
-    ///
-    /// Forces `q_m * (w_l * w_r) + w_4 * q_4 + q_c + PI = w_o(computed by the
-    /// gate)`.
-    ///
-    /// `{w_l, w_r, w_4} = {a, b, d}`
-    pub fn big_mul(
-        &mut self,
-        q_m: E::Fr,
-        a: Variable,
-        b: Variable,
-        q_4_d: Option<(E::Fr, Variable)>,
-        q_c: E::Fr,
-        pi: Option<E::Fr>,
-    ) -> Variable {
-        let q_o = -E::Fr::one();
-
-        // Check if advice wire is available
-        let (q_4, d) = match q_4_d {
-            Some((q_4, var)) => (q_4, var),
-            None => (E::Fr::zero(), self.zero_var),
-        };
-
-        // Compute output wire
-        let a_eval = self.variables[&a];
-        let b_eval = self.variables[&b];
-        let d_eval = self.variables[&d];
-        let c_eval = (q_m * a_eval * b_eval)
-            + (q_4 * d_eval)
-            + q_c
-            + pi.unwrap_or_default();
-        let c = self.add_input(c_eval);
-
-        self.big_mul_gate(a, b, c, Some(d), q_m, q_o, q_c, q_4, pi)
-    }
-
-    /// Adds a [`StandardComposer::big_arith_gate`] with the left, right
-    /// , fourth inputs and corresponding coefficients, computing & returning
-    /// the output (result) [`Variable`] and adding the corresponding arith
-    /// constraint.
-    ///
-    /// This type of gate is usually used when we don't need to have
-    /// the largest amount of performance and the minimum circuit-size
-    /// possible, since it defaults set `q_o` to `-1` to reduce the verbosity.
-    ///
-    /// Equation: `(a*b)*q_m + a*q_l + b*q_r + d*q_4 + q_c + PI = c`
-    /// ### Returns
-    /// `c`
-    pub fn big_arith(
-        &mut self,
-        q_m: E::Fr,
-        a: Variable,
-        b: Variable,
-        q_l: E::Fr,
-        q_r: E::Fr,
-        q_4_d: Option<(E::Fr, Variable)>,
-        q_c: E::Fr,
-        pi: Option<E::Fr>,
-    ) -> Variable {
-        // check if advice wire is available
-        let (q_4, d) = match q_4_d {
-            Some((q_4, d)) => (q_4, d),
-            None => (E::Fr::zero(), self.zero_var),
-        };
-
-        // compute output wire
-        let a_eval = self.variables[&a];
-        let b_eval = self.variables[&b];
-        let d_eval = self.variables[&d];
-
-        let c_eval = (q_m * a_eval * b_eval)
-            + (q_l * a_eval)
-            + (q_r * b_eval)
-            + (q_4 * d_eval)
-            + q_c
-            + pi.unwrap_or_default();
-
-        let c = self.add_input(c_eval);
-
-        self.big_arith_gate(
-            a,
-            b,
+        self.perm.add_variables_to_map(
+            gate_witness.0,
+            gate_witness.1,
             c,
-            Some(d),
-            q_m,
-            q_l,
-            q_r,
-            -E::Fr::one(),
-            q_c,
-            q_4,
-            pi,
-        )
+            w4,
+            self.n,
+        );
+        self.n += 1;
+
+        c
     }
 }
 
@@ -440,6 +167,9 @@ mod test {
     use crate::constraint_system::helper::*;
     use ark_bls12_377::Bls12_377;
     use ark_bls12_381::Bls12_381;
+    use ark_ec::PairingEngine;
+    use ark_ec::TEModelParameters;
+    use num_traits::One;
 
     fn test_public_inputs<E, P>()
     where
@@ -449,25 +179,25 @@ mod test {
         let res = gadget_tester(
             |composer: &mut StandardComposer<E, P>| {
                 let var_one = composer.add_input(E::Fr::one());
-                let should_be_three = composer.big_add(
-                    (E::Fr::one(), var_one),
-                    (E::Fr::one(), var_one),
-                    None,
-                    E::Fr::zero(),
-                    Some(E::Fr::one()),
-                );
+
+                let should_be_three = composer.arithmetic_gate(|gate| {
+                    gate.witness((var_one, var_one, None))
+                        .add((E::Fr::one(), E::Fr::one()))
+                        .pi(E::Fr::one())
+                });
+
                 composer.constrain_to_constant(
                     should_be_three,
                     E::Fr::from(3u64),
                     None,
                 );
-                let should_be_four = composer.big_add(
-                    (E::Fr::one(), var_one),
-                    (E::Fr::one(), var_one),
-                    None,
-                    E::Fr::zero(),
-                    Some(E::Fr::from(2u64)),
-                );
+
+                let should_be_four = composer.arithmetic_gate(|gate| {
+                    gate.witness((var_one, var_one, None))
+                        .add((E::Fr::one(), E::Fr::one()))
+                        .pi(E::Fr::from(2u64))
+                });
+
                 composer.constrain_to_constant(
                     should_be_four,
                     E::Fr::from(4u64),
@@ -492,36 +222,29 @@ mod test {
                 let six = composer.add_input(E::Fr::from(6u64));
                 let seven = composer.add_input(E::Fr::from(7u64));
 
-                let fourteen = composer.big_add(
-                    (E::Fr::one(), four),
-                    (E::Fr::one(), five),
-                    Some((E::Fr::one(), five)),
-                    E::Fr::zero(),
-                    None,
-                );
+                let fourteen = composer.arithmetic_gate(|gate| {
+                    gate.witness((four, five, None))
+                        .add((E::Fr::one(), E::Fr::one()))
+                        .pi(E::Fr::from(2u64))
+                });
 
-                let twenty = composer.big_add(
-                    (E::Fr::one(), six),
-                    (E::Fr::one(), seven),
-                    Some((E::Fr::one(), seven)),
-                    E::Fr::zero(),
-                    None,
-                );
+                let twenty = composer.arithmetic_gate(|gate| {
+                    gate.witness((six, seven, None))
+                        .add((E::Fr::one(), E::Fr::one()))
+                        .fan_in_3((E::Fr::one(), seven))
+                });
 
                 // There are quite a few ways to check the equation is correct,
                 // depending on your circumstance If we already
                 // have the output wire, we can constrain the output of the
                 // mul_gate to be equal to it If we do not, we
-                // can compute it using the `mul` If the output
+                // can compute it using an `arithmetic_gate`. If the output
                 // is public, we can also constrain the output wire of the mul
                 // gate to it. This is what this test does
-                let output = composer.mul(
-                    E::Fr::one(),
-                    fourteen,
-                    twenty,
-                    E::Fr::zero(),
-                    None,
-                );
+                let output = composer.arithmetic_gate(|gate| {
+                    gate.witness((fourteen, twenty, None)).mul(E::Fr::one())
+                });
+
                 composer.constrain_to_constant(
                     output,
                     E::Fr::from(280u64),
@@ -543,12 +266,12 @@ mod test {
                 let zero = composer.zero_var();
                 let one = composer.add_input(E::Fr::one());
 
-                let c = composer.add(
-                    (E::Fr::one(), one),
-                    (E::Fr::zero(), zero),
-                    E::Fr::from(2u64),
-                    None,
-                );
+                let c = composer.arithmetic_gate(|gate| {
+                    gate.witness((one, zero, None))
+                        .add((E::Fr::one(), E::Fr::one()))
+                        .const_sel(E::Fr::from(2u64))
+                });
+
                 composer.constrain_to_constant(c, E::Fr::from(3u64), None);
             },
             32,
@@ -570,30 +293,24 @@ mod test {
                 let seven = composer.add_input(E::Fr::from(7u64));
                 let nine = composer.add_input(E::Fr::from(9u64));
 
-                let fourteen = composer.big_add(
-                    (E::Fr::one(), four),
-                    (E::Fr::one(), five),
-                    Some((E::Fr::one(), five)),
-                    E::Fr::zero(),
-                    None,
-                );
+                let fourteen = composer.arithmetic_gate(|gate| {
+                    gate.witness((four, five, None))
+                        .add((E::Fr::one(), E::Fr::one()))
+                        .fan_in_3((E::Fr::one(), five))
+                });
 
-                let twenty = composer.big_add(
-                    (E::Fr::one(), six),
-                    (E::Fr::one(), seven),
-                    Some((E::Fr::one(), seven)),
-                    E::Fr::zero(),
-                    None,
-                );
+                let twenty = composer.arithmetic_gate(|gate| {
+                    gate.witness((six, seven, None))
+                        .add((E::Fr::one(), E::Fr::one()))
+                        .fan_in_3((E::Fr::one(), seven))
+                });
 
-                let output = composer.big_mul(
-                    E::Fr::one(),
-                    fourteen,
-                    twenty,
-                    Some((E::Fr::from(8u64), nine)),
-                    E::Fr::zero(),
-                    None,
-                );
+                let output = composer.arithmetic_gate(|gate| {
+                    gate.witness((fourteen, twenty, None))
+                        .mul(E::Fr::one())
+                        .fan_in_3((E::Fr::from(8u64), nine))
+                });
+
                 composer.constrain_to_constant(
                     output,
                     E::Fr::from(352u64),
@@ -695,29 +412,21 @@ mod test {
                 let six = composer.add_input(E::Fr::from(6u64));
                 let seven = composer.add_input(E::Fr::from(7u64));
 
-                let five_plus_five = composer.big_add(
-                    (E::Fr::one(), five),
-                    (E::Fr::one(), five),
-                    None,
-                    E::Fr::zero(),
-                    None,
-                );
+                let five_plus_five = composer.arithmetic_gate(|gate| {
+                    gate.witness((five, five, None))
+                        .add((E::Fr::one(), E::Fr::one()))
+                });
 
-                let six_plus_seven = composer.big_add(
-                    (E::Fr::one(), six),
-                    (E::Fr::one(), seven),
-                    None,
-                    E::Fr::zero(),
-                    None,
-                );
+                let six_plus_seven = composer.arithmetic_gate(|gate| {
+                    gate.witness((six, seven, None))
+                        .add((E::Fr::one(), E::Fr::one()))
+                });
 
-                let output = composer.mul(
-                    E::Fr::one(),
-                    five_plus_five,
-                    six_plus_seven,
-                    E::Fr::zero(),
-                    None,
-                );
+                let output = composer.arithmetic_gate(|gate| {
+                    gate.witness((five_plus_five, six_plus_seven, None))
+                        .add((E::Fr::one(), E::Fr::one()))
+                });
+
                 composer.constrain_to_constant(
                     output,
                     E::Fr::from(117u64),

--- a/src/constraint_system/arithmetic.rs
+++ b/src/constraint_system/arithmetic.rs
@@ -114,6 +114,8 @@ impl<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>>
         };
 
         let gate_witness = gate.witness.unwrap();
+        self.w_l.push(gate_witness.0);
+        self.w_r.push(gate_witness.1);
         self.q_l.push(gate.add_selectors.0);
         self.q_r.push(gate.add_selectors.1);
 
@@ -143,7 +145,7 @@ impl<E: PairingEngine, P: TEModelParameters<BaseField = E::Fr>>
                     + gate.const_selector
                     + q4 * self.variables[&w4]
                     + gate.pi)
-                    * gate.out_selector,
+                    * (-gate.out_selector),
             )
         });
         self.w_o.push(c);
@@ -225,7 +227,7 @@ mod test {
                 let fourteen = composer.arithmetic_gate(|gate| {
                     gate.witness((four, five, None))
                         .add((E::Fr::one(), E::Fr::one()))
-                        .pi(E::Fr::from(2u64))
+                        .pi(E::Fr::from(5u64))
                 });
 
                 let twenty = composer.arithmetic_gate(|gate| {
@@ -339,16 +341,13 @@ mod test {
                 let q_4 = E::Fr::from(10u64);
                 let q_c = E::Fr::from(11u64);
 
-                let output = composer.big_arith(
-                    q_m,
-                    a,
-                    b,
-                    q_l,
-                    q_r,
-                    Some((q_4, d)),
-                    q_c,
-                    None,
-                );
+                let output = composer.arithmetic_gate(|gate| {
+                    gate.witness((a, b, None))
+                        .mul(q_m)
+                        .add((q_l, q_r))
+                        .fan_in_3((q_4, d))
+                        .const_sel(q_c)
+                });
 
                 composer.constrain_to_constant(
                     output,
@@ -378,16 +377,13 @@ mod test {
                 let q_4 = E::Fr::from(12u64);
                 let q_c = E::Fr::from(11u64);
 
-                let output = composer.big_arith(
-                    q_m,
-                    a,
-                    b,
-                    q_l,
-                    q_r,
-                    Some((q_4, d)),
-                    q_c,
-                    None,
-                );
+                let output = composer.arithmetic_gate(|gate| {
+                    gate.witness((a, b, None))
+                        .mul(q_m)
+                        .add((q_l, q_r))
+                        .fan_in_3((q_4, d))
+                        .const_sel(q_c)
+                });
 
                 composer.constrain_to_constant(
                     output,

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -356,29 +356,29 @@ where
         choice_a: Variable,
         choice_b: Variable,
     ) -> Variable {
+        let zero = self.zero_var;
         // bit * choice_a
-        let bit_times_a =
-            self.mul(E::Fr::one(), bit, choice_a, E::Fr::zero(), None);
+        let bit_times_a = self.arithmetic_gate(|gate| {
+            gate.witness((bit, choice_a, None)).mul(E::Fr::one())
+        });
 
         // 1 - bit
-        let one_min_bit = self.add(
-            (-E::Fr::one(), bit),
-            (E::Fr::zero(), self.zero_var),
-            E::Fr::one(),
-            None,
-        );
+        let one_min_bit = self.arithmetic_gate(|gate| {
+            gate.witness((bit, zero, None))
+                .add((-E::Fr::one(), E::Fr::one()))
+        });
 
         // (1 - bit) * b
-        let one_min_bit_choice_b =
-            self.mul(E::Fr::one(), one_min_bit, choice_b, E::Fr::zero(), None);
+        let one_min_bit_choice_b = self.arithmetic_gate(|gate| {
+            gate.witness((one_min_bit, choice_b, None))
+                .mul(E::Fr::one())
+        });
 
         // [ (1 - bit) * b ] + [ bit * a ]
-        self.add(
-            (E::Fr::one(), one_min_bit_choice_b),
-            (E::Fr::one(), bit_times_a),
-            E::Fr::zero(),
-            None,
-        )
+        self.arithmetic_gate(|gate| {
+            gate.witness((one_min_bit_choice_b, bit_times_a, None))
+                .add((E::Fr::one(), E::Fr::one()))
+        })
     }
 
     /// Adds the polynomial f(x) = x * a to the circuit description where
@@ -396,7 +396,9 @@ where
         value: Variable,
     ) -> Variable {
         // returns bit * value
-        self.mul(E::Fr::one(), bit, value, E::Fr::zero(), None)
+        self.arithmetic_gate(|gate| {
+            gate.witness((bit, value, None)).mul(E::Fr::one())
+        })
     }
 
     /// Adds the polynomial f(x) = 1 - x + xa to the circuit description where

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -365,7 +365,8 @@ where
         // 1 - bit
         let one_min_bit = self.arithmetic_gate(|gate| {
             gate.witness((bit, zero, None))
-                .add((-E::Fr::one(), E::Fr::one()))
+                .add((-E::Fr::one(), E::Fr::zero()))
+                .const_sel(E::Fr::one())
         });
 
         // (1 - bit) * b

--- a/src/constraint_system/composer.rs
+++ b/src/constraint_system/composer.rs
@@ -45,8 +45,8 @@ use num_traits::{One, Zero};
 /// The StandardComposer also contains as associated functions all the
 /// neccessary tools to be able to istrument the circuits that the user needs
 /// through the addition of gates. There are functions that may add a single
-/// gate to the circuit as for example [`StandardComposer::add_gate`] and others
-/// that can add several gates to the circuit description such as
+/// arithmetic gate to the circuit [`StandardComposer::arithmetic_gate`] and
+/// others that can add several gates to the circuit description such as
 /// [`StandardComposer::conditional_select`].
 ///
 /// Each gate or group of gates adds an specific functionallity or operation to
@@ -359,26 +359,25 @@ where
         let zero = self.zero_var;
         // bit * choice_a
         let bit_times_a = self.arithmetic_gate(|gate| {
-            gate.witness((bit, choice_a, None)).mul(E::Fr::one())
+            gate.witness(bit, choice_a, None).mul(E::Fr::one())
         });
 
         // 1 - bit
         let one_min_bit = self.arithmetic_gate(|gate| {
-            gate.witness((bit, zero, None))
-                .add((-E::Fr::one(), E::Fr::zero()))
-                .const_sel(E::Fr::one())
+            gate.witness(bit, zero, None)
+                .add(-E::Fr::one(), E::Fr::zero())
+                .constant(E::Fr::one())
         });
 
         // (1 - bit) * b
         let one_min_bit_choice_b = self.arithmetic_gate(|gate| {
-            gate.witness((one_min_bit, choice_b, None))
-                .mul(E::Fr::one())
+            gate.witness(one_min_bit, choice_b, None).mul(E::Fr::one())
         });
 
         // [ (1 - bit) * b ] + [ bit * a ]
         self.arithmetic_gate(|gate| {
-            gate.witness((one_min_bit_choice_b, bit_times_a, None))
-                .add((E::Fr::one(), E::Fr::one()))
+            gate.witness(one_min_bit_choice_b, bit_times_a, None)
+                .add(E::Fr::one(), E::Fr::one())
         })
     }
 
@@ -398,7 +397,7 @@ where
     ) -> Variable {
         // returns bit * value
         self.arithmetic_gate(|gate| {
-            gate.witness((bit, value, None)).mul(E::Fr::one())
+            gate.witness(bit, value, None).mul(E::Fr::one())
         })
     }
 
@@ -671,8 +670,7 @@ mod test {
     use super::*;
     use crate::batch_test;
     use crate::constraint_system::helper::*;
-    use crate::prelude::Prover;
-    use crate::prelude::Verifier;
+    use crate::proof_system::{Prover, Verifier};
     use ark_bls12_377::Bls12_377;
     use ark_bls12_381::Bls12_381;
     use ark_poly::univariate::DensePolynomial;

--- a/src/constraint_system/ecc/curve_addition/variable_base_gate.rs
+++ b/src/constraint_system/ecc/curve_addition/variable_base_gate.rs
@@ -110,11 +110,8 @@ mod test {
         composer: &mut StandardComposer<E, P>,
         point_a: Point<E, P>,
         point_b: Point<E, P>,
-    ) -> Point<E, P>
-    where
-        E: PairingEngine,
-        P: TEModelParameters<BaseField = E::Fr>,
-    {
+    ) -> Point<E, P> {
+        let zero = composer.zero_var;
         let x1 = point_a.x;
         let y1 = point_a.y;
 
@@ -122,40 +119,44 @@ mod test {
         let y2 = point_b.y;
 
         // x1 * y2
-        let x1_y2 = composer.mul(E::Fr::one(), x1, y2, E::Fr::zero(), None);
+        let x1_y2 = composer.arithmetic_gate(|gate| {
+            gate.mul(E::Fr::one()).witness((x1, y2, None))
+        });
         // y1 * x2
-        let y1_x2 = composer.mul(E::Fr::one(), y1, x2, E::Fr::zero(), None);
+        let y1_x2 = composer.arithmetic_gate(|gate| {
+            gate.mul(E::Fr::one()).witness((y1, x2, None))
+        });
         // y1 * y2
-        let y1_y2 = composer.mul(E::Fr::one(), y1, y2, E::Fr::zero(), None);
+        let y1_y2 = composer.arithmetic_gate(|gate| {
+            gate.mul(E::Fr::one()).witness((y1, y2, None))
+        });
         // x1 * x2
-        let x1_x2 = composer.mul(E::Fr::one(), x1, x2, E::Fr::zero(), None);
+        let x1_x2 = composer.arithmetic_gate(|gate| {
+            gate.mul(E::Fr::one()).witness((x1, x2, None))
+        });
         // d x1x2 * y1y2
-        let d_x1_x2_y1_y2 =
-            composer.mul(P::COEFF_D, x1_x2, y1_y2, E::Fr::zero(), None);
+        let d_x1_x2_y1_y2 = composer.arithmetic_gate(|gate| {
+            gate.mul(P::COEFF_D).witness((x1_x2, y1_y2, None))
+        });
 
         // x1y2 + y1x2
-        let x_numerator = composer.add(
-            (E::Fr::one(), x1_y2),
-            (E::Fr::one(), y1_x2),
-            E::Fr::zero(),
-            None,
-        );
+        let x_numerator = composer.arithmetic_gate(|gate| {
+            gate.witness((x1_y2, y1_x2, None))
+                .add((E::Fr::one(), E::Fr::one()))
+        });
 
         // y1y2 - a * x1x2 (a=-1) => y1y2 + x1x2
-        let y_numerator = composer.add(
-            (E::Fr::one(), y1_y2),
-            (E::Fr::one(), x1_x2),
-            E::Fr::zero(),
-            None,
-        );
+        let y_numerator = composer.arithmetic_gate(|gate| {
+            gate.witness((y1_y2, x1_x2, None))
+                .add((E::Fr::one(), E::Fr::one()))
+        });
 
         // 1 + dx1x2y1y2
-        let x_denominator = composer.add(
-            (E::Fr::one(), d_x1_x2_y1_y2),
-            (E::Fr::zero(), composer.zero_var),
-            E::Fr::one(),
-            None,
-        );
+        let x_denominator = composer.arithmetic_gate(|gate| {
+            gate.witness((d_x1_x2_y1_y2, zero, None))
+                .add((E::Fr::one(), E::Fr::zero()))
+                .const_sel(E::Fr::one())
+        });
 
         // Compute the inverse
         let inv_x_denom = composer
@@ -168,23 +169,19 @@ mod test {
 
         // Assert that we actually have the inverse
         // inv_x * x = 1
-        composer.mul_gate(
-            x_denominator,
-            inv_x_denom,
-            composer.zero_var,
-            E::Fr::one(),
-            E::Fr::zero(),
-            -E::Fr::one(),
-            None,
-        );
+        composer.arithmetic_gate(|gate| {
+            gate.witness((x_denominator, inv_x_denom, Some(zero)))
+                .mul(E::Fr::one())
+                .const_sel(-E::Fr::one())
+        });
 
         // 1 - dx1x2y1y2
-        let y_denominator = composer.add(
-            (-E::Fr::one(), d_x1_x2_y1_y2),
-            (E::Fr::zero(), composer.zero_var),
-            E::Fr::one(),
-            None,
-        );
+        let y_denominator = composer.arithmetic_gate(|gate| {
+            gate.witness((d_x1_x2_y1_y2, zero, None))
+                .add((E::Fr::one(), E::Fr::zero()))
+                .const_sel(E::Fr::one())
+        });
+
         let inv_y_denom = composer
             .variables
             .get(&y_denominator)
@@ -194,32 +191,23 @@ mod test {
         let inv_y_denom = composer.add_input(inv_y_denom);
         // Assert that we actually have the inverse
         // inv_y * y = 1
-        composer.mul_gate(
-            y_denominator,
-            inv_y_denom,
-            composer.zero_var,
-            E::Fr::one(),
-            E::Fr::zero(),
-            -E::Fr::one(),
-            None,
-        );
+        composer.arithmetic_gate(|gate| {
+            gate.mul(E::Fr::one())
+                .witness((y_denominator, inv_y_denom, None))
+                .const_sel(-E::Fr::one())
+        });
 
         // We can now use the inverses
 
-        let x_3 = composer.mul(
-            E::Fr::one(),
-            inv_x_denom,
-            x_numerator,
-            E::Fr::zero(),
-            None,
-        );
-        let y_3 = composer.mul(
-            E::Fr::one(),
-            inv_y_denom,
-            y_numerator,
-            E::Fr::zero(),
-            None,
-        );
+        let x_3 = composer.arithmetic_gate(|gate| {
+            gate.mul(E::Fr::one())
+                .witness((inv_x_denom, x_numerator, None))
+        });
+
+        let y_3 = composer.arithmetic_gate(|gate| {
+            gate.mul(E::Fr::one())
+                .witness((inv_y_denom, y_numerator, None))
+        });
 
         Point::new(x_3, y_3)
     }

--- a/src/constraint_system/ecc/curve_addition/variable_base_gate.rs
+++ b/src/constraint_system/ecc/curve_addition/variable_base_gate.rs
@@ -110,7 +110,11 @@ mod test {
         composer: &mut StandardComposer<E, P>,
         point_a: Point<E, P>,
         point_b: Point<E, P>,
-    ) -> Point<E, P> {
+    ) -> Point<E, P>
+    where
+        E: PairingEngine,
+        P: TEModelParameters<BaseField = E::Fr>,
+    {
         let zero = composer.zero_var;
         let x1 = point_a.x;
         let y1 = point_a.y;
@@ -178,7 +182,7 @@ mod test {
         // 1 - dx1x2y1y2
         let y_denominator = composer.arithmetic_gate(|gate| {
             gate.witness((d_x1_x2_y1_y2, zero, None))
-                .add((E::Fr::one(), E::Fr::zero()))
+                .add((-E::Fr::one(), E::Fr::zero()))
                 .const_sel(E::Fr::one())
         });
 
@@ -188,12 +192,13 @@ mod test {
             .unwrap()
             .inverse()
             .unwrap();
+
         let inv_y_denom = composer.add_input(inv_y_denom);
         // Assert that we actually have the inverse
         // inv_y * y = 1
         composer.arithmetic_gate(|gate| {
             gate.mul(E::Fr::one())
-                .witness((y_denominator, inv_y_denom, None))
+                .witness((y_denominator, inv_y_denom, Some(zero)))
                 .const_sel(-E::Fr::one())
         });
 

--- a/src/constraint_system/ecc/curve_addition/variable_base_gate.rs
+++ b/src/constraint_system/ecc/curve_addition/variable_base_gate.rs
@@ -124,42 +124,42 @@ mod test {
 
         // x1 * y2
         let x1_y2 = composer.arithmetic_gate(|gate| {
-            gate.mul(E::Fr::one()).witness((x1, y2, None))
+            gate.mul(E::Fr::one()).witness(x1, y2, None)
         });
         // y1 * x2
         let y1_x2 = composer.arithmetic_gate(|gate| {
-            gate.mul(E::Fr::one()).witness((y1, x2, None))
+            gate.mul(E::Fr::one()).witness(y1, x2, None)
         });
         // y1 * y2
         let y1_y2 = composer.arithmetic_gate(|gate| {
-            gate.mul(E::Fr::one()).witness((y1, y2, None))
+            gate.mul(E::Fr::one()).witness(y1, y2, None)
         });
         // x1 * x2
         let x1_x2 = composer.arithmetic_gate(|gate| {
-            gate.mul(E::Fr::one()).witness((x1, x2, None))
+            gate.mul(E::Fr::one()).witness(x1, x2, None)
         });
         // d x1x2 * y1y2
         let d_x1_x2_y1_y2 = composer.arithmetic_gate(|gate| {
-            gate.mul(P::COEFF_D).witness((x1_x2, y1_y2, None))
+            gate.mul(P::COEFF_D).witness(x1_x2, y1_y2, None)
         });
 
         // x1y2 + y1x2
         let x_numerator = composer.arithmetic_gate(|gate| {
-            gate.witness((x1_y2, y1_x2, None))
-                .add((E::Fr::one(), E::Fr::one()))
+            gate.witness(x1_y2, y1_x2, None)
+                .add(E::Fr::one(), E::Fr::one())
         });
 
         // y1y2 - a * x1x2 (a=-1) => y1y2 + x1x2
         let y_numerator = composer.arithmetic_gate(|gate| {
-            gate.witness((y1_y2, x1_x2, None))
-                .add((E::Fr::one(), E::Fr::one()))
+            gate.witness(y1_y2, x1_x2, None)
+                .add(E::Fr::one(), E::Fr::one())
         });
 
         // 1 + dx1x2y1y2
         let x_denominator = composer.arithmetic_gate(|gate| {
-            gate.witness((d_x1_x2_y1_y2, zero, None))
-                .add((E::Fr::one(), E::Fr::zero()))
-                .const_sel(E::Fr::one())
+            gate.witness(d_x1_x2_y1_y2, zero, None)
+                .add(E::Fr::one(), E::Fr::zero())
+                .constant(E::Fr::one())
         });
 
         // Compute the inverse
@@ -174,16 +174,16 @@ mod test {
         // Assert that we actually have the inverse
         // inv_x * x = 1
         composer.arithmetic_gate(|gate| {
-            gate.witness((x_denominator, inv_x_denom, Some(zero)))
+            gate.witness(x_denominator, inv_x_denom, Some(zero))
                 .mul(E::Fr::one())
-                .const_sel(-E::Fr::one())
+                .constant(-E::Fr::one())
         });
 
         // 1 - dx1x2y1y2
         let y_denominator = composer.arithmetic_gate(|gate| {
-            gate.witness((d_x1_x2_y1_y2, zero, None))
-                .add((-E::Fr::one(), E::Fr::zero()))
-                .const_sel(E::Fr::one())
+            gate.witness(d_x1_x2_y1_y2, zero, None)
+                .add(-E::Fr::one(), E::Fr::zero())
+                .constant(E::Fr::one())
         });
 
         let inv_y_denom = composer
@@ -198,20 +198,20 @@ mod test {
         // inv_y * y = 1
         composer.arithmetic_gate(|gate| {
             gate.mul(E::Fr::one())
-                .witness((y_denominator, inv_y_denom, Some(zero)))
-                .const_sel(-E::Fr::one())
+                .witness(y_denominator, inv_y_denom, Some(zero))
+                .constant(-E::Fr::one())
         });
 
         // We can now use the inverses
 
         let x_3 = composer.arithmetic_gate(|gate| {
             gate.mul(E::Fr::one())
-                .witness((inv_x_denom, x_numerator, None))
+                .witness(inv_x_denom, x_numerator, None)
         });
 
         let y_3 = composer.arithmetic_gate(|gate| {
             gate.mul(E::Fr::one())
-                .witness((inv_y_denom, y_numerator, None))
+                .witness(inv_y_denom, y_numerator, None)
         });
 
         Point::new(x_3, y_3)

--- a/src/constraint_system/ecc/mod.rs
+++ b/src/constraint_system/ecc/mod.rs
@@ -176,8 +176,8 @@ where
 
         // negation of point (x, y) is (-x, y)
         let x_neg = self.arithmetic_gate(|gate| {
-            gate.witness((x, zero, None))
-                .add((-E::Fr::one(), E::Fr::zero()))
+            gate.witness(x, zero, None)
+                .add(-E::Fr::one(), E::Fr::zero())
         });
 
         let x_updated = self.conditional_select(bit, x_neg, x);

--- a/src/constraint_system/ecc/mod.rs
+++ b/src/constraint_system/ecc/mod.rs
@@ -170,16 +170,16 @@ where
         bit: Variable,
         point_b: Point<E, P>,
     ) -> Point<E, P> {
+        let zero = self.zero_var;
         let x = point_b.x;
         let y = point_b.y;
 
         // negation of point (x, y) is (-x, y)
-        let x_neg = self.add(
-            (-E::Fr::one(), x),
-            (E::Fr::zero(), self.zero_var),
-            E::Fr::zero(),
-            None,
-        );
+        let x_neg = self.arithmetic_gate(|gate| {
+            gate.witness((x, zero, None))
+                .add((-E::Fr::one(), E::Fr::zero()))
+        });
+
         let x_updated = self.conditional_select(bit, x_neg, x);
 
         Point::new(x_updated, y)

--- a/src/constraint_system/ecc/scalar_mul/fixed_base.rs
+++ b/src/constraint_system/ecc/scalar_mul/fixed_base.rs
@@ -151,18 +151,11 @@ where
         let xy_alpha = self.zero_var;
         let last_accumulated_bit = self.add_input(scalar_acc[num_bits]);
 
-        self.big_add_gate(
-            acc_x,
-            acc_y,
-            xy_alpha,
-            Some(last_accumulated_bit),
-            E::Fr::zero(),
-            E::Fr::zero(),
-            E::Fr::zero(),
-            E::Fr::zero(),
-            E::Fr::zero(),
-            None,
-        );
+        self.arithmetic_gate(|gate| {
+            gate.witness((acc_x, acc_y, Some(xy_alpha)))
+                .fan_in_3((E::Fr::zero(), last_accumulated_bit))
+                .out(E::Fr::zero())
+        });
 
         // Constrain the last element in the accumulator to be equal to the
         // input scalar.

--- a/src/constraint_system/ecc/scalar_mul/fixed_base.rs
+++ b/src/constraint_system/ecc/scalar_mul/fixed_base.rs
@@ -152,8 +152,8 @@ where
         let last_accumulated_bit = self.add_input(scalar_acc[num_bits]);
 
         self.arithmetic_gate(|gate| {
-            gate.witness((acc_x, acc_y, Some(xy_alpha)))
-                .fan_in_3((E::Fr::zero(), last_accumulated_bit))
+            gate.witness(acc_x, acc_y, Some(xy_alpha))
+                .fan_in_3(E::Fr::zero(), last_accumulated_bit)
                 .out(E::Fr::zero())
         });
 

--- a/src/constraint_system/ecc/scalar_mul/variable_base.rs
+++ b/src/constraint_system/ecc/scalar_mul/variable_base.rs
@@ -84,11 +84,10 @@ where
 
             let two_pow = E::Fr::from(2u64).pow([power as u64, 0, 0, 0]);
 
-            let q_l_a = (two_pow, *bit);
-            let q_r_b = (E::Fr::one(), accumulator_var);
-            let q_c = E::Fr::zero();
-
-            accumulator_var = self.add(q_l_a, q_r_b, q_c, None);
+            accumulator_var = self.arithmetic_gate(|gate| {
+                gate.witness((*bit, accumulator_var, None))
+                    .add((two_pow, E::Fr::one()))
+            });
 
             accumulator_scalar +=
                 two_pow * E::Fr::from(scalar_bits_iter[power] as u64);

--- a/src/constraint_system/ecc/scalar_mul/variable_base.rs
+++ b/src/constraint_system/ecc/scalar_mul/variable_base.rs
@@ -85,8 +85,8 @@ where
             let two_pow = E::Fr::from(2u64).pow([power as u64, 0, 0, 0]);
 
             accumulator_var = self.arithmetic_gate(|gate| {
-                gate.witness((*bit, accumulator_var, None))
-                    .add((two_pow, E::Fr::one()))
+                gate.witness(*bit, accumulator_var, None)
+                    .add(two_pow, E::Fr::one())
             });
 
             accumulator_scalar +=

--- a/src/constraint_system/helper.rs
+++ b/src/constraint_system/helper.rs
@@ -29,8 +29,8 @@ pub(crate) fn dummy_gadget<E, P>(
     let var_one = composer.add_input(one);
     for _ in 0..n {
         composer.arithmetic_gate(|gate| {
-            gate.witness((var_one, var_one, None))
-                .add((E::Fr::one(), E::Fr::one()))
+            gate.witness(var_one, var_one, None)
+                .add(E::Fr::one(), E::Fr::one())
         });
     }
 }

--- a/src/constraint_system/helper.rs
+++ b/src/constraint_system/helper.rs
@@ -13,7 +13,7 @@ use ark_poly::univariate::DensePolynomial;
 use ark_poly_commit::kzg10::{self, Powers, KZG10};
 use ark_poly_commit::sonic_pc::SonicKZG10;
 use ark_poly_commit::PolynomialCommitment;
-use num_traits::{One, Zero};
+use num_traits::One;
 use rand_core::OsRng;
 
 /// Adds dummy constraints using arithmetic gates.
@@ -28,13 +28,10 @@ pub(crate) fn dummy_gadget<E, P>(
     let one = E::Fr::one();
     let var_one = composer.add_input(one);
     for _ in 0..n {
-        composer.big_add(
-            (E::Fr::one(), var_one),
-            (E::Fr::one(), var_one),
-            None,
-            E::Fr::zero(),
-            None,
-        );
+        composer.arithmetic_gate(|gate| {
+            gate.witness((var_one, var_one, None))
+                .add((E::Fr::one(), E::Fr::one()))
+        });
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,7 +84,6 @@ impl From<ark_poly_commit::error::Error> for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -143,5 +142,4 @@ impl std::fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
 impl std::error::Error for Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,23 +6,21 @@
 //
 // Copyright (c) ZK-INFRA. All rights reserved.
 
-//#![doc = include_str!("../README.md")]
-//! Permutations over Lagrange-bases for Oecumenical Noninteractive
-//! arguments of Knowledge (PLONK) is a zero knowledge proof system.
+//! # PLONK
+//! ![Build Status](https://github.com/rust-zkp/ark-plonk/workflows/Continuous%20integration/badge.svg)
+//! [![Repository](https://img.shields.io/badge/github-plonk-blueviolet?logo=github)](https://github.com/rust-zkp/ark-plonk)
+//! [![Documentation](https://img.shields.io/badge/docs-plonk-blue?logo=rust)](https://docs.rs/plonk/)
 //!
-//! This protocol was created by:
-//! - Ariel Gabizon (Protocol Labs),
-//! - Zachary J. Williamson (Aztec Protocol)
-//! - Oana Ciobotaru
 //!
-//! This crate contains a pure Rust implementation of this algorithm using
-//! code done by the creators of the protocol as a reference implementation:
+//! _This is a pure Rust implementation of the PLONK zk proving system_
 //!
-//! <https://github.com/AztecProtocol/barretenberg/blob/master/barretenberg/src/aztec/plonk/>
 //!
-//! If you want to see library usage examples, please check:
-//! <https://github.com/dusk-network/plonk/tree/v0.1.0/examples>
-
+//! ## About
+//! Initial implementation created by [Kev](https://github.com/kevaundray), [Carlos](https://github.com/CPerezz) and [Luke](https://github.com/LukePearson1) at Dusk Network.
+//! Redesigned by the [rust zkp](https://github.com/rust-zkp) team to have a backend which is compatible with the [arkworks](https://github.com/arkworks-rs) suite. This allows us to leverage the multitude of curves
+//! and optimised algebra present in various arkworks repositories.
+//!
+#![doc = include_str!("../test_circuit.md")]
 // Bitshift/Bitwise ops are allowed to gain performance.
 #![allow(clippy::suspicious_arithmetic_impl)]
 // Some structs do not have AddAssign or MulAssign impl.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@
 //! Initial implementation created by [Kev](https://github.com/kevaundray), [Carlos](https://github.com/CPerezz) and [Luke](https://github.com/LukePearson1) at Dusk Network.
 //! Redesigned by the [rust zkp](https://github.com/rust-zkp) team to have a backend which is compatible with the [arkworks](https://github.com/arkworks-rs) suite. This allows us to leverage the multitude of curves
 //! and optimised algebra present in various arkworks repositories.
-//!
 #![doc = include_str!("../test_circuit.md")]
 // Bitshift/Bitwise ops are allowed to gain performance.
 #![allow(clippy::suspicious_arithmetic_impl)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,9 +12,12 @@
 //! data structures of the plonk library.
 
 pub use crate::{
-    circuit::{self, Circuit, PublicInputValue, VerifierData},
+    circuit::{
+        self, verify_proof, Circuit, FeIntoPubInput, GeIntoPubInput,
+        PublicInputValue, VerifierData,
+    },
     constraint_system::{ecc::Point, StandardComposer, Variable},
     error::Error,
-    proof_system::{Proof, VerifierKey},
-    proof_system::{Prover, ProverKey, Verifier},
+    proof_system::{Proof, ProverKey, VerifierKey},
+    util::from_embedded_curve_scalar,
 };

--- a/src/util.rs
+++ b/src/util.rs
@@ -133,6 +133,7 @@ where
     P: TEModelParameters<BaseField = E::Fr>,
 {
     let scalar_repr = embedded_scalar.into_repr();
+
     let modulus = <<E::Fr as PrimeField>::Params as FpParameters>::MODULUS;
     if modulus.num_bits() >= scalar_repr.num_bits() {
         let s = <<E::Fr as PrimeField>::BigInt as BigInteger>::from_bits_le(

--- a/src/util.rs
+++ b/src/util.rs
@@ -125,7 +125,7 @@ where
 /// curve. Panics if the embedded scalar is greater than the modulus of the
 /// pairing firendly curve scalar field
 #[allow(dead_code)]
-pub(crate) fn from_embedded_curve_scalar<E, P>(
+pub fn from_embedded_curve_scalar<E, P>(
     embedded_scalar: <P as ModelParameters>::ScalarField,
 ) -> E::Fr
 where


### PR DESCRIPTION
The best representation to show how this changes the way of writing circuits is:
```rust
let output = composer.big_arith(
    q_m,
    a,
    b,
    q_l,
    q_r,
    Some((q_4, d)),
    q_c,
    None,
);
```

Now is done as:
```rust
let output = composer.arithmetic_gate(|gate| {
    gate.witness(a, b, None)
        .mul(q_m)
        .add(q_l, q_r)
        .fan_in_3(q_4, d)
        .constant(q_c)
});
```
@ZK-Garage/infra might want to take a look before accepting.
Resolves: #46