### PR TITLE
Provide Basic Test Utilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,15 +2,15 @@
 name = "ark-plonk"
 version = "0.8.2"
 authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>",
-           "Luke Pearson <luke@polychain.capital>",
-           "Jules De Smit <jules@aleo.org>",
-           "Joshua Fitzgerald <joshua@heliax.dev>",
-           "Carlos Perez <carlos.perezbaro@iohk.io>",
-           "David Nevado <david.nevado@iohk.io>"]
+    "Luke Pearson <luke@polychain.capital>",
+    "Jules De Smit <jules@aleo.org>",
+    "Joshua Fitzgerald <joshua@heliax.dev>",
+    "Carlos Perez <carlos.perezbaro@iohk.io>",
+    "David Nevado <david.nevado@iohk.io>"]
 readme = "README.md"
 repository = "https://github.com/rust-zkp/ark-plonk"
 keywords = ["cryptography", "plonk", "zk-snarks", "zero-knowledge", "crypto"]
-categories =["algorithms", "cryptography", "science"]
+categories = ["algorithms", "cryptography", "science"]
 description = "A pure-Rust implementation of the PLONK ZK-Proof algorithm."
 exclude = [
     "**/.gitignore",
@@ -64,6 +64,7 @@ asm = [
 ]
 trace = []
 trace-print = ["trace"]
+test = []
 
 [[bench]]
 name = "plonk"

--- a/src/constraint_system/mod.rs
+++ b/src/constraint_system/mod.rs
@@ -16,7 +16,8 @@ mod logic;
 mod range;
 
 pub(crate) mod composer;
-pub(crate) mod helper;
+#[cfg(any(test, feature = "test"))]
+pub mod helper;
 pub(crate) mod variable;
 
 pub mod ecc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub mod error;
 pub mod prelude;
 pub mod proof_system;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test"))]
 mod test;
 
 #[doc = include_str!("../docs/notes-intro.md")]

--- a/src/test.rs
+++ b/src/test.rs
@@ -2,6 +2,7 @@
 ///
 /// The set of tests is split in two. The first set between `[]` is for regular
 /// tests that should not panic. The second set is for tests that should panic.
+#[cfg(test)]
 #[macro_export]
 macro_rules! batch_test {
     ( [$($test_set:ident),*], [$($test_panic_set:ident),*] => ($engine:ty, $params:ty) ) => {
@@ -24,3 +25,6 @@ macro_rules! batch_test {
         }
     }
 }
+
+#[cfg(feature = "test")]
+pub use crate::constraint_system::helper::*;


### PR DESCRIPTION
This PR makes `gadget_tester` and `batch_test!` public. 

Note that currently, the user needs to manually import `paste` as their dev dependency to use `batch_test!`. Is there a better way? 

Also, ping me if there's a better place to put those test utilities (instead of simply making them public and re-export)

closes: #51 