### PR TITLE
Use  `COEFF_A` in embedded curve operations

### DIFF
--- a/plonk-core/src/constraint_system/ecc/curve_addition/variable_base_gate.rs
+++ b/plonk-core/src/constraint_system/ecc/curve_addition/variable_base_gate.rs
@@ -147,10 +147,10 @@ mod test {
                 .add(E::Fr::one(), E::Fr::one())
         });
 
-        // y1y2 - a * x1x2 (a=-1) => y1y2 + x1x2
+        // y1y2 - a * x1x2
         let y_numerator = composer.arithmetic_gate(|gate| {
             gate.witness(y1_y2, x1_x2, None)
-                .add(E::Fr::one(), E::Fr::one())
+                .add(E::Fr::one(), -P::COEFF_A)
         });
 
         // 1 + dx1x2y1y2


### PR DESCRIPTION
The addition formulas used in the tests were coded for the original embedded curve (Jubjub). 
One of the parameters of this curve `a=-1` was still coded directly in one of the formulas. It has been substituted with `COEFF_A` from `TEModelParameters`.
Closes #65 