### PR TITLE
Refactor Custom Gates

### DIFF
--- a/plonk-core/src/proof_system/linearisation_poly.rs
+++ b/plonk-core/src/proof_system/linearisation_poly.rs
@@ -122,9 +122,13 @@ where
 
     /// Add evaluation of poly at point if the label is not already
     /// in the set of evaluations
-    pub fn add(label: String, poly: DensePolynomial<F>, point: F) {
-        // TODO
-        unimplemented!()
+    pub fn add(&mut self, label: &str, poly: DensePolynomial<F>, point: F) {
+        if let Some(_l) = &self.vals.iter().find(|entry| entry.0 == label) {
+            return;
+        } else {
+            let eval = poly.evaluate(&point);
+            let _ = &self.vals.push((label.to_string(), eval));
+        }
     }
 }
 

--- a/plonk-core/src/proof_system/linearisation_poly.rs
+++ b/plonk-core/src/proof_system/linearisation_poly.rs
@@ -8,11 +8,11 @@ use crate::{
     error::Error,
     label_eval,
     proof_system::{
-        ecc::{CurveAddition, FixedBaseScalarMul},
-        logic::Logic,
-        range::Range,
+        ecc::{CAVals, CurveAddition, FBSMVals, FixedBaseScalarMul},
+        logic::{Logic, LogicVals},
+        range::{Range, RangeVals},
         widget::GateConstraint,
-        ProverKey, WitnessValues,
+        CustomValues, ProverKey, WitnessValues,
     },
     util::EvaluationDomainExt,
 };
@@ -24,13 +24,6 @@ use ark_poly::{
 };
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write,
-};
-
-use super::{
-    ecc::{CAVals, FBSMVals},
-    logic::LogicVals,
-    range::RangeVals,
-    CustomValues,
 };
 
 /// Subset of the [`ProofEvaluations`]. Evaluations at `z` of the

--- a/plonk-core/src/proof_system/linearisation_poly.rs
+++ b/plonk-core/src/proof_system/linearisation_poly.rs
@@ -263,14 +263,13 @@ where
     let vanishing_poly_eval =
         domain.evaluate_vanishing_polynomial(*z_challenge);
     let z_challenge_to_n = vanishing_poly_eval + F::one();
-    let z_challenge_to_2n = z_challenge_to_n * z_challenge_to_n;
-    let z_challenge_to_3n = z_challenge_to_2n * z_challenge_to_n;
 
-    // TODO optimize multiplications by add then mul
-    let quotient_term = &(t_1_poly
-        + &(t_2_poly * z_challenge_to_n)
-        + t_3_poly * z_challenge_to_2n
-        + t_4_poly * z_challenge_to_3n)
+    let quotient_term = &(&(&(&(&(&(t_4_poly * z_challenge_to_n)
+        + t_3_poly)
+        * z_challenge_to_n)
+        + t_2_poly)
+        * z_challenge_to_n)
+        + t_1_poly)
         * vanishing_poly_eval;
     let negative_quotient_term = &quotient_term * (-F::one());
 

--- a/plonk-core/src/proof_system/linearisation_poly.rs
+++ b/plonk-core/src/proof_system/linearisation_poly.rs
@@ -28,7 +28,7 @@ use ark_serialize::{
 };
 
 use super::{
-    ecc::{CAVals, FSMVals},
+    ecc::{CAVals, FBSMVals},
     logic::LogicVals,
     range::RangeVals,
     CustomValues,
@@ -324,7 +324,7 @@ where
         &prover_key.fixed_group_add_selector.0,
         *fixed_base_separation_challenge,
         wit_vals,
-        FSMVals::from_evaluations(custom_evals),
+        FBSMVals::from_evaluations(custom_evals),
     );
 
     let curve_addition = CurveAddition::<F, P>::linearisation_term(

--- a/plonk-core/src/proof_system/linearisation_poly.rs
+++ b/plonk-core/src/proof_system/linearisation_poly.rs
@@ -33,23 +33,6 @@ use super::{
     CustomValues,
 };
 
-/// Polynomial Evaluations
-///
-/// This `struct` keeps track of polynomial evaluations at points `z` and/or `z
-/// * w` where `w` is a root of unit.
-#[derive(CanonicalDeserialize, CanonicalSerialize, derivative::Derivative)]
-#[derivative(Clone, Debug, Default, Eq, PartialEq)]
-pub struct Evaluations<F>
-where
-    F: Field,
-{
-    /// Proof-relevant Evaluations
-    pub proof: ProofEvaluations<F>,
-    // TODO Remove the whole sttructure
-    // Evaluation of the linearisation sigma polynomial at `z`.
-    // pub quot_eval: F,
-}
-
 /// Subset of the [`ProofEvaluations`]. Evaluations at `z` of the
 /// wire polynomials
 #[derive(CanonicalDeserialize, CanonicalSerialize, derivative::Derivative)]
@@ -130,8 +113,7 @@ where
     }
 }
 
-/// Subset of all of the evaluations. These evaluations
-/// are added to the [`Proof`](super::Proof).
+/// Set of evaluations that form the [`Proof`](super::Proof).
 #[derive(CanonicalDeserialize, CanonicalSerialize, derivative::Derivative)]
 #[derivative(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ProofEvaluations<F>
@@ -176,7 +158,7 @@ pub fn compute<F, P>(
     t_3_poly: &DensePolynomial<F>,
     t_4_poly: &DensePolynomial<F>,
     z_poly: &DensePolynomial<F>,
-) -> Result<(DensePolynomial<F>, Evaluations<F>), Error>
+) -> Result<(DensePolynomial<F>, ProofEvaluations<F>), Error>
 where
     F: PrimeField,
     P: TEModelParameters<BaseField = F>,
@@ -277,13 +259,11 @@ where
         gate_constraints + permutation + negative_quotient_term;
     Ok((
         linearisation_polynomial,
-        Evaluations {
-            proof: ProofEvaluations {
-                wire_evals,
-                q_arith_eval,
-                perm_evals,
-                custom_evals,
-            },
+        ProofEvaluations {
+            wire_evals,
+            q_arith_eval,
+            perm_evals,
+            custom_evals,
         },
     ))
 }

--- a/plonk-core/src/proof_system/linearisation_poly.rs
+++ b/plonk-core/src/proof_system/linearisation_poly.rs
@@ -5,7 +5,6 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::{
-    constraint_system::WireData,
     error::Error,
     label_eval,
     proof_system::{
@@ -310,28 +309,28 @@ where
         &prover_key.range_selector.0,
         *range_separation_challenge,
         wit_vals,
-        RangeVals::from_evaluations(custom_evals),
+        RangeVals::from_evaluations(&custom_evals),
     );
 
     let logic = Logic::linearisation_term(
         &prover_key.logic_selector.0,
         *logic_separation_challenge,
         wit_vals,
-        LogicVals::from_evaluations(custom_evals),
+        LogicVals::from_evaluations(&custom_evals),
     );
 
     let fixed_base_scalar_mul = FixedBaseScalarMul::<F, P>::linearisation_term(
         &prover_key.fixed_group_add_selector.0,
         *fixed_base_separation_challenge,
         wit_vals,
-        FBSMVals::from_evaluations(custom_evals),
+        FBSMVals::from_evaluations(&custom_evals),
     );
 
     let curve_addition = CurveAddition::<F, P>::linearisation_term(
         &prover_key.variable_group_add_selector.0,
         *var_base_separation_challenge,
         wit_vals,
-        CAVals::from_evaluations(custom_evals),
+        CAVals::from_evaluations(&custom_evals),
     );
 
     arithmetic + range + logic + fixed_base_scalar_mul + curve_addition

--- a/plonk-core/src/proof_system/linearisation_poly.rs
+++ b/plonk-core/src/proof_system/linearisation_poly.rs
@@ -105,7 +105,6 @@ where
     /// in the set of evaluations
     pub fn add(&mut self, label: &str, poly: DensePolynomial<F>, point: F) {
         if let Some(_l) = &self.vals.iter().find(|entry| entry.0 == label) {
-            return;
         } else {
             let eval = poly.evaluate(&point);
             let _ = &self.vals.push((label.to_string(), eval));
@@ -297,28 +296,28 @@ where
         &prover_key.range_selector.0,
         *range_separation_challenge,
         wit_vals,
-        RangeVals::from_evaluations(&custom_evals),
+        RangeVals::from_evaluations(custom_evals),
     );
 
     let logic = Logic::linearisation_term(
         &prover_key.logic_selector.0,
         *logic_separation_challenge,
         wit_vals,
-        LogicVals::from_evaluations(&custom_evals),
+        LogicVals::from_evaluations(custom_evals),
     );
 
     let fixed_base_scalar_mul = FixedBaseScalarMul::<F, P>::linearisation_term(
         &prover_key.fixed_group_add_selector.0,
         *fixed_base_separation_challenge,
         wit_vals,
-        FBSMVals::from_evaluations(&custom_evals),
+        FBSMVals::from_evaluations(custom_evals),
     );
 
     let curve_addition = CurveAddition::<F, P>::linearisation_term(
         &prover_key.variable_group_add_selector.0,
         *var_base_separation_challenge,
         wit_vals,
-        CAVals::from_evaluations(&custom_evals),
+        CAVals::from_evaluations(custom_evals),
     );
 
     arithmetic + range + logic + fixed_base_scalar_mul + curve_addition

--- a/plonk-core/src/proof_system/linearisation_poly.rs
+++ b/plonk-core/src/proof_system/linearisation_poly.rs
@@ -129,12 +129,6 @@ where
     /// Evaluations needed for custom gates. This includes selector polynomials
     /// and evaluations of wire polynomials at an offset
     pub custom_evals: CustomEvaluations<F>,
-
-    // The arithmetic gates is not considered custom
-    // TODO It can be considered optional -> It should be removed when there
-    // are no other gates (a purely arithmetic circuit)
-    /// Evaluation of the arithmetic selector polynomial at `z`.
-    pub q_arith_eval: F,
 }
 
 /// Compute the linearisation polynomial.
@@ -208,6 +202,7 @@ where
 
     let custom_evals = CustomEvaluations {
         vals: vec![
+            label_eval!(q_arith_eval),
             label_eval!(q_c_eval),
             label_eval!(q_l_eval),
             label_eval!(q_r_eval),
@@ -261,7 +256,6 @@ where
         linearisation_polynomial,
         ProofEvaluations {
             wire_evals,
-            q_arith_eval,
             perm_evals,
             custom_evals,
         },

--- a/plonk-core/src/proof_system/linearisation_poly.rs
+++ b/plonk-core/src/proof_system/linearisation_poly.rs
@@ -5,6 +5,7 @@
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
 use crate::{
+    constraint_system::WireData,
     error::Error,
     label_eval,
     proof_system::{
@@ -110,7 +111,7 @@ where
 {
     /// Get the evaluation of the specified label.
     /// This funtions panics if the requested label is not found
-    pub fn get(&self, label: String) -> F {
+    pub fn get(&self, label: &str) -> F {
         if let Some(result) = &self.vals.iter().find(|entry| entry.0 == label) {
             result.1
         } else {
@@ -239,10 +240,7 @@ where
         logic_separation_challenge,
         fixed_base_separation_challenge,
         var_base_separation_challenge,
-        a_eval,
-        b_eval,
-        c_eval,
-        d_eval,
+        wire_evals,
         q_arith_eval,
         custom_evals,
         prover_key,
@@ -284,10 +282,7 @@ fn compute_gate_constraint_satisfiability<F, P>(
     logic_separation_challenge: &F,
     fixed_base_separation_challenge: &F,
     var_base_separation_challenge: &F,
-    a_eval: F,
-    b_eval: F,
-    c_eval: F,
-    d_eval: F,
+    wire_evals: WireEvaluations<F>,
     q_arith_eval: F,
     custom_evals: CustomEvaluations<F>,
     prover_key: &ProverKey<F>,
@@ -297,17 +292,17 @@ where
     P: TEModelParameters<BaseField = F>,
 {
     let wit_vals = WitnessValues {
-        a_eval,
-        b_eval,
-        c_eval,
-        d_eval,
+        a_val: wire_evals.a_eval,
+        b_val: wire_evals.b_eval,
+        c_val: wire_evals.c_eval,
+        d_val: wire_evals.d_eval,
     };
 
     let arithmetic = prover_key.arithmetic.compute_linearisation(
-        a_eval,
-        b_eval,
-        c_eval,
-        d_eval,
+        wire_evals.a_eval,
+        wire_evals.b_eval,
+        wire_evals.c_eval,
+        wire_evals.d_eval,
         q_arith_eval,
     );
 

--- a/plonk-core/src/proof_system/linearisation_poly.rs
+++ b/plonk-core/src/proof_system/linearisation_poly.rs
@@ -37,6 +37,8 @@ use super::{
 ///
 /// This `struct` keeps track of polynomial evaluations at points `z` and/or `z
 /// * w` where `w` is a root of unit.
+#[derive(CanonicalDeserialize, CanonicalSerialize, derivative::Derivative)]
+#[derivative(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Evaluations<F>
 where
     F: Field,
@@ -51,7 +53,7 @@ where
 /// Subset of the [`ProofEvaluations`]. Evaluations at `z` of the
 /// wire polynomials
 #[derive(CanonicalDeserialize, CanonicalSerialize, derivative::Derivative)]
-#[derivative(Clone, Debug, Default, Eq, PartialEq)]
+#[derivative(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct WireEvaluations<F>
 where
     F: Field,
@@ -72,7 +74,7 @@ where
 /// Subset of the [`ProofEvaluations`]. Evaluations of the sigma and permutation
 /// polynomials at `z`  or `z *w` where `w` is the nth root of unity.
 #[derive(CanonicalDeserialize, CanonicalSerialize, derivative::Derivative)]
-#[derivative(Clone, Debug, Default, Eq, PartialEq)]
+#[derivative(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PermutationEvaluations<F>
 where
     F: Field,
@@ -239,9 +241,9 @@ where
         logic_separation_challenge,
         fixed_base_separation_challenge,
         var_base_separation_challenge,
-        wire_evals,
+        &wire_evals,
         q_arith_eval,
-        custom_evals,
+        &custom_evals,
         prover_key,
     );
 
@@ -281,9 +283,9 @@ fn compute_gate_constraint_satisfiability<F, P>(
     logic_separation_challenge: &F,
     fixed_base_separation_challenge: &F,
     var_base_separation_challenge: &F,
-    wire_evals: WireEvaluations<F>,
+    wire_evals: &WireEvaluations<F>,
     q_arith_eval: F,
-    custom_evals: CustomEvaluations<F>,
+    custom_evals: &CustomEvaluations<F>,
     prover_key: &ProverKey<F>,
 ) -> DensePolynomial<F>
 where

--- a/plonk-core/src/proof_system/linearisation_poly.rs
+++ b/plonk-core/src/proof_system/linearisation_poly.rs
@@ -101,8 +101,6 @@ pub struct CustomEvaluations<F>
 where
     F: Field,
 {
-    // TODO: Decide best data structure
-    // pub vals: HashMap<Into<String>, F>,
     pub vals: Vec<(String, F)>,
 }
 
@@ -155,10 +153,6 @@ where
     // are no other gates (a purely arithmetic circuit)
     /// Evaluation of the arithmetic selector polynomial at `z`.
     pub q_arith_eval: F,
-    // TODO This evaluation can be removed, making the adjustment for the
-    // linearisation polynomial proposed in the last version of the print
-    // Evaluation of the linearisation sigma polynomial at `z`.
-    // pub linearisation_polynomial_eval: F,
 }
 
 /// Compute the linearisation polynomial.

--- a/plonk-core/src/proof_system/permutation.rs
+++ b/plonk-core/src/proof_system/permutation.rs
@@ -340,16 +340,17 @@ where
         // * k3 * z + gamma) * alpha
         let x = {
             let beta_z = beta * z_challenge;
-            let q_0 = evaluations.a_eval + beta_z + gamma;
+            let q_0 = evaluations.wire_evals.a_eval + beta_z + gamma;
 
             let beta_k1_z = beta * K1::<F>() * z_challenge;
-            let q_1 = evaluations.b_eval + beta_k1_z + gamma;
+            let q_1 = evaluations.wire_evals.b_eval + beta_k1_z + gamma;
 
             let beta_k2_z = beta * K2::<F>() * z_challenge;
-            let q_2 = evaluations.c_eval + beta_k2_z + gamma;
+            let q_2 = evaluations.wire_evals.c_eval + beta_k2_z + gamma;
 
             let beta_k3_z = beta * K3::<F>() * z_challenge;
-            let q_3 = (evaluations.d_eval + beta_k3_z + gamma) * alpha;
+            let q_3 =
+                (evaluations.wire_evals.d_eval + beta_k3_z + gamma) * alpha;
 
             q_0 * q_1 * q_2 * q_3
         };
@@ -364,16 +365,16 @@ where
         // sigma_2_eval + gamma)(c_eval + beta * sigma_3_eval +
         // gamma) * alpha^2
         let y = {
-            let beta_sigma_1 = beta * evaluations.left_sigma_eval;
-            let q_0 = evaluations.a_eval + beta_sigma_1 + gamma;
+            let beta_sigma_1 = beta * evaluations.perm_evals.left_sigma_eval;
+            let q_0 = evaluations.wire_evals.a_eval + beta_sigma_1 + gamma;
 
-            let beta_sigma_2 = beta * evaluations.right_sigma_eval;
-            let q_1 = evaluations.b_eval + beta_sigma_2 + gamma;
+            let beta_sigma_2 = beta * evaluations.perm_evals.right_sigma_eval;
+            let q_1 = evaluations.wire_evals.b_eval + beta_sigma_2 + gamma;
 
-            let beta_sigma_3 = beta * evaluations.out_sigma_eval;
-            let q_2 = evaluations.c_eval + beta_sigma_3 + gamma;
+            let beta_sigma_3 = beta * evaluations.perm_evals.out_sigma_eval;
+            let q_2 = evaluations.wire_evals.c_eval + beta_sigma_3 + gamma;
 
-            let q_3 = beta * evaluations.permutation_eval * alpha;
+            let q_3 = beta * evaluations.perm_evals.permutation_eval * alpha;
 
             -(q_0 * q_1 * q_2 * q_3)
         };

--- a/plonk-core/src/proof_system/proof.rs
+++ b/plonk-core/src/proof_system/proof.rs
@@ -220,7 +220,8 @@ where
             .vals
             .iter()
             .map(|(label, eval)| {
-                transcript.append(label.to_owned().as_bytes(), eval);
+                let static_label = Box::leak(label.to_owned().into_boxed_str());
+                transcript.append(static_label.as_bytes(), eval);
             });
 
         transcript.append(b"t_eval", &t_eval);

--- a/plonk-core/src/proof_system/proof.rs
+++ b/plonk-core/src/proof_system/proof.rs
@@ -180,27 +180,8 @@ where
             l1_eval,
             self.evaluations.perm_evals.permutation_eval,
         );
-        // Compute quotient polynomial evaluated at `z_challenge`
-        // let t_eval = self.compute_quotient_evaluation(
-        //     &domain,
-        //     pub_inputs,
-        //     alpha,
-        //     beta,
-        //     gamma,
-        //     z_challenge,
-        //     z_h_eval,
-        //     l1_eval,
-        //     self.evaluations.perm_evals.permutation_eval,
-        // );
-
-        // Compute commitment to quotient polynomial
-        // This method is necessary as we pass the `un-splitted` variation
-        // to our commitment scheme
-        // let t_comm =
-        //     self.compute_quotient_commitment(&z_challenge, domain.size());
 
         // Add evaluations to transcript
-
         transcript.append(b"a_eval", &self.evaluations.wire_evals.a_eval);
         transcript.append(b"b_eval", &self.evaluations.wire_evals.b_eval);
         transcript.append(b"c_eval", &self.evaluations.wire_evals.c_eval);
@@ -299,8 +280,6 @@ where
             label_commitment!(self.d_comm),
         ];
 
-        // TODO These custom values (a_next, b_next, d_next) should not be
-        // harcoded
         let saw_evals = [
             self.evaluations.perm_evals.permutation_eval,
             self.evaluations.custom_evals.get("a_next_eval"),

--- a/plonk-core/src/proof_system/proof.rs
+++ b/plonk-core/src/proof_system/proof.rs
@@ -206,8 +206,6 @@ where
         transcript.append(b"c_eval", &self.evaluations.wire_evals.c_eval);
         transcript.append(b"d_eval", &self.evaluations.wire_evals.d_eval);
 
-        transcript.append(b"q_arith_eval", &self.evaluations.q_arith_eval);
-
         transcript.append(
             b"left_sig_eval",
             &self.evaluations.perm_evals.left_sigma_eval,

--- a/plonk-core/src/proof_system/proof.rs
+++ b/plonk-core/src/proof_system/proof.rs
@@ -219,7 +219,7 @@ where
             .custom_evals
             .vals
             .iter()
-            .map(|(label, eval)| {
+            .for_each(|(label, eval)| {
                 let static_label = Box::leak(label.to_owned().into_boxed_str());
                 transcript.append(static_label.as_bytes(), eval);
             });

--- a/plonk-core/src/proof_system/proof.rs
+++ b/plonk-core/src/proof_system/proof.rs
@@ -234,12 +234,6 @@ where
                 transcript.append(static_label.as_bytes(), eval);
             });
 
-        // TODO elimnate this
-        // transcript.append(b"t_eval", &t_eval);
-        // transcript
-        //     .append(b"r_eval",
-        // &self.evaluations.linearisation_polynomial_eval);
-
         // Compute linearisation commitment
         let lin_comm = self.compute_linearisation_commitment::<P>(
             &domain,
@@ -386,74 +380,6 @@ where
         // Return r_0
         pi_eval - b - c
     }
-
-    // TODO: Remove this
-    // fn compute_quotient_evaluation(
-    //     &self,
-    //     domain: &GeneralEvaluationDomain<F>,
-    //     pub_inputs: &[F],
-    //     alpha: F,
-    //     beta: F,
-    //     gamma: F,
-    //     z_challenge: F,
-    //     z_h_eval: F,
-    //     l1_eval: F,
-    //     z_hat_eval: F,
-    // ) -> F {
-    //     // Compute the public input polynomial evaluated at `z_challenge`
-    //     let pi_eval = compute_barycentric_eval(pub_inputs, z_challenge,
-    // domain);
-
-    //     let alpha_sq = alpha.square();
-    //     // r + PI(z)
-    //     let a = self.evaluations.linearisation_polynomial_eval + pi_eval;
-
-    //     // a + beta * sigma_1 + gamma
-    //     let beta_sig1 = beta * self.evaluations.perm_evals.left_sigma_eval;
-    //     let b_0 = self.evaluations.wire_evals.a_eval + beta_sig1 + gamma;
-
-    //     // b+ beta * sigma_2 + gamma
-    //     let beta_sig2 = beta * self.evaluations.perm_evals.right_sigma_eval;
-    //     let b_1 = self.evaluations.wire_evals.b_eval + beta_sig2 + gamma;
-
-    //     // c+ beta * sigma_3 + gamma
-    //     let beta_sig3 = beta * self.evaluations.perm_evals.out_sigma_eval;
-    //     let b_2 = self.evaluations.wire_evals.c_eval + beta_sig3 + gamma;
-
-    //     // ((d + gamma) * z_hat) * alpha
-    //     let b_3 =
-    //         (self.evaluations.wire_evals.d_eval + gamma) * z_hat_eval *
-    // alpha;
-
-    //     let b = b_0 * b_1 * b_2 * b_3;
-
-    //     // l_1(z) * alpha^2
-    //     let c = l1_eval * alpha_sq;
-
-    //     // Return t_eval
-    //     (a - b - c) * z_h_eval.inverse().unwrap()
-    // }
-    // /// Computes the quotient polynomial commitment at `z_challenge`.
-    // fn compute_quotient_commitment(
-    //     &self,
-    //     z_challenge: &F,
-    //     n: usize,
-    // ) -> PC::Commitment {
-    //     let n = n as u64;
-    //     let z_n = z_challenge.pow(&[n, 0, 0, 0]);
-    //     let z_two_n = z_challenge.pow(&[2 * n, 0, 0, 0]);
-    //     let z_three_n = z_challenge.pow(&[3 * n, 0, 0, 0]);
-
-    //     PC::multi_scalar_mul(
-    //         &[
-    //             self.t_1_comm.clone(),
-    //             self.t_2_comm.clone(),
-    //             self.t_3_comm.clone(),
-    //             self.t_4_comm.clone(),
-    //         ],
-    //         &[F::one(), z_n, z_two_n, z_three_n],
-    //     )
-    // }
 
     /// Computes the commitment to `[r]_1`.
     fn compute_linearisation_commitment<P>(

--- a/plonk-core/src/proof_system/prover.rs
+++ b/plonk-core/src/proof_system/prover.rs
@@ -123,25 +123,26 @@ where
         )
     }
 
+    // TODO: no longer needed, eliminate
     /// Computes the quotient Opening [`DensePolynomial`].
-    fn compute_quotient_opening_poly(
-        n: usize,
-        t_1_poly: &DensePolynomial<F>,
-        t_2_poly: &DensePolynomial<F>,
-        t_3_poly: &DensePolynomial<F>,
-        t_4_poly: &DensePolynomial<F>,
-        z_challenge: &F,
-    ) -> DensePolynomial<F> {
-        // Compute z^n , z^2n , z^3n
-        let z_n = z_challenge.pow(&[n as u64, 0, 0, 0]);
-        let z_two_n = z_challenge.pow(&[2 * n as u64, 0, 0, 0]);
-        let z_three_n = z_challenge.pow(&[3 * n as u64, 0, 0, 0]);
-        let a = t_1_poly;
-        let b = t_2_poly * z_n;
-        let c = t_3_poly * z_two_n;
-        let d = t_4_poly * z_three_n;
-        a + &b + c + d
-    }
+    // fn compute_quotient_opening_poly(
+    //     n: usize,
+    //     t_1_poly: &DensePolynomial<F>,
+    //     t_2_poly: &DensePolynomial<F>,
+    //     t_3_poly: &DensePolynomial<F>,
+    //     t_4_poly: &DensePolynomial<F>,
+    //     z_challenge: &F,
+    // ) -> DensePolynomial<F> {
+    //     // Compute z^n , z^2n , z^3n
+    //     let z_n = z_challenge.pow(&[n as u64, 0, 0, 0]);
+    //     let z_two_n = z_challenge.pow(&[2 * n as u64, 0, 0, 0]);
+    //     let z_three_n = z_challenge.pow(&[3 * n as u64, 0, 0, 0]);
+    //     let a = t_1_poly;
+    //     let b = t_2_poly * z_n;
+    //     let c = t_3_poly * z_two_n;
+    //     let d = t_4_poly * z_three_n;
+    //     a + &b + c + d
+    // }
 
     /// Convert variables to their actual witness values.
     fn to_scalars(&self, vars: &[Variable]) -> Vec<F> {
@@ -403,7 +404,10 @@ where
             &w_r_poly,
             &w_o_poly,
             &w_4_poly,
-            &t_poly,
+            &t_1_poly,
+            &t_2_poly,
+            &t_3_poly,
+            &t_4_poly,
             &z_poly,
         )?;
 
@@ -445,59 +449,28 @@ where
                 let static_label = Box::leak(label.to_owned().into_boxed_str());
                 transcript.append(static_label.as_bytes(), eval);
             });
-        // transcript.append(
-        //     b"a_next_eval",
-        //     &evaluations.proof.custom_evals.get("a_next_eval"),
-        // );
-        // transcript.append(
-        //     b"b_next_eval",
-        //     &evaluations.proof.custom_evals.get("b_next_eval"),
-        // );
-        // transcript.append(
-        //     b"d_next_eval",
-        //     &evaluations.proof.custom_evals.get("d_next_eval"),
-        // );
-
-        // transcript.append(
-        //     b"q_c_eval",
-        //     &evaluations.proof.custom_evals.get("q_c_eval"),
-        // );
-        // transcript.append(
-        //     b"q_l_eval",
-        //     &evaluations.proof.custom_evals.get("q_l_eval"),
-        // );
-        // transcript.append(
-        //     b"q_r_eval",
-        //     &evaluations.proof.custom_evals.get("q_r_eval"),
-        // );
-
-        // Lastly, quotient and lienearisation poly evals
-        transcript.append(b"t_eval", &evaluations.quot_eval);
-        transcript.append(
-            b"r_eval",
-            &evaluations.proof.linearisation_polynomial_eval,
-        );
 
         // 5. Compute Openings using KZG10
         //
         // We merge the quotient polynomial using the `z_challenge` so the SRS
         // is linear in the circuit size `n`
 
-        let quot = Self::compute_quotient_opening_poly(
-            n,
-            &t_1_poly,
-            &t_2_poly,
-            &t_3_poly,
-            &t_4_poly,
-            &z_challenge,
-        );
+        //TODO eliminate this
+        // let quot = Self::compute_quotient_opening_poly(
+        //     n,
+        //     &t_1_poly,
+        //     &t_2_poly,
+        //     &t_3_poly,
+        //     &t_4_poly,
+        //     &z_challenge,
+        // );
 
         // Compute aggregate witness to polynomials evaluated at the evaluation
         // challenge `z`
         let aw_challenge: F = transcript.challenge_scalar(b"aggregate_witness");
 
         let aw_polys = [
-            label_polynomial!(quot),
+            // label_polynomial!(quot),
             label_polynomial!(lin_poly),
             label_polynomial!(prover_key.permutation.left_sigma.0.clone()),
             label_polynomial!(prover_key.permutation.right_sigma.0.clone()),

--- a/plonk-core/src/proof_system/prover.rs
+++ b/plonk-core/src/proof_system/prover.rs
@@ -397,9 +397,6 @@ where
         transcript.append(b"c_eval", &evaluations.wire_evals.c_eval);
         transcript.append(b"d_eval", &evaluations.wire_evals.d_eval);
 
-        // TODO Decide if arith_selector should be custom
-        transcript.append(b"q_arith_eval", &evaluations.q_arith_eval);
-
         // Second permutation evals
         transcript
             .append(b"left_sig_eval", &evaluations.perm_evals.left_sigma_eval);

--- a/plonk-core/src/proof_system/prover.rs
+++ b/plonk-core/src/proof_system/prover.rs
@@ -442,7 +442,8 @@ where
             .vals
             .iter()
             .map(|(label, eval)| {
-                transcript.append(label.as_bytes(), eval);
+                let static_label = Box::leak(label.to_owned().into_boxed_str());
+                transcript.append(static_label.as_bytes(), eval);
             });
         // transcript.append(
         //     b"a_next_eval",

--- a/plonk-core/src/proof_system/prover.rs
+++ b/plonk-core/src/proof_system/prover.rs
@@ -408,22 +408,69 @@ where
         )?;
 
         // Add evaluations to transcript.
-        transcript.append(b"a_eval", &evaluations.proof.a_eval);
-        transcript.append(b"b_eval", &evaluations.proof.b_eval);
-        transcript.append(b"c_eval", &evaluations.proof.c_eval);
-        transcript.append(b"d_eval", &evaluations.proof.d_eval);
-        transcript.append(b"a_next_eval", &evaluations.proof.a_next_eval);
-        transcript.append(b"b_next_eval", &evaluations.proof.b_next_eval);
-        transcript.append(b"d_next_eval", &evaluations.proof.d_next_eval);
-        transcript.append(b"left_sig_eval", &evaluations.proof.left_sigma_eval);
-        transcript
-            .append(b"right_sig_eval", &evaluations.proof.right_sigma_eval);
-        transcript.append(b"out_sig_eval", &evaluations.proof.out_sigma_eval);
+        // First wire evals
+        transcript.append(b"a_eval", &evaluations.proof.wire_evals.a_eval);
+        transcript.append(b"b_eval", &evaluations.proof.wire_evals.b_eval);
+        transcript.append(b"c_eval", &evaluations.proof.wire_evals.c_eval);
+        transcript.append(b"d_eval", &evaluations.proof.wire_evals.d_eval);
+
+        // TODO Decide if arith_selector should be custom
         transcript.append(b"q_arith_eval", &evaluations.proof.q_arith_eval);
-        transcript.append(b"q_c_eval", &evaluations.proof.q_c_eval);
-        transcript.append(b"q_l_eval", &evaluations.proof.q_l_eval);
-        transcript.append(b"q_r_eval", &evaluations.proof.q_r_eval);
-        transcript.append(b"perm_eval", &evaluations.proof.permutation_eval);
+
+        // Second permutation evals
+        transcript.append(
+            b"left_sig_eval",
+            &evaluations.proof.perm_evals.left_sigma_eval,
+        );
+        transcript.append(
+            b"right_sig_eval",
+            &evaluations.proof.perm_evals.right_sigma_eval,
+        );
+        transcript.append(
+            b"out_sig_eval",
+            &evaluations.proof.perm_evals.out_sigma_eval,
+        );
+        transcript.append(
+            b"perm_eval",
+            &evaluations.proof.perm_evals.permutation_eval,
+        );
+
+        // Third, all evals needed for custom gates
+        evaluations
+            .proof
+            .custom_evals
+            .vals
+            .iter()
+            .map(|(label, eval)| {
+                transcript.append(label.as_bytes(), eval);
+            });
+        // transcript.append(
+        //     b"a_next_eval",
+        //     &evaluations.proof.custom_evals.get("a_next_eval"),
+        // );
+        // transcript.append(
+        //     b"b_next_eval",
+        //     &evaluations.proof.custom_evals.get("b_next_eval"),
+        // );
+        // transcript.append(
+        //     b"d_next_eval",
+        //     &evaluations.proof.custom_evals.get("d_next_eval"),
+        // );
+
+        // transcript.append(
+        //     b"q_c_eval",
+        //     &evaluations.proof.custom_evals.get("q_c_eval"),
+        // );
+        // transcript.append(
+        //     b"q_l_eval",
+        //     &evaluations.proof.custom_evals.get("q_l_eval"),
+        // );
+        // transcript.append(
+        //     b"q_r_eval",
+        //     &evaluations.proof.custom_evals.get("q_r_eval"),
+        // );
+
+        // Lastly, quotient and lienearisation poly evals
         transcript.append(b"t_eval", &evaluations.quot_eval);
         transcript.append(
             b"r_eval",

--- a/plonk-core/src/proof_system/prover.rs
+++ b/plonk-core/src/proof_system/prover.rs
@@ -392,35 +392,28 @@ where
 
         // Add evaluations to transcript.
         // First wire evals
-        transcript.append(b"a_eval", &evaluations.proof.wire_evals.a_eval);
-        transcript.append(b"b_eval", &evaluations.proof.wire_evals.b_eval);
-        transcript.append(b"c_eval", &evaluations.proof.wire_evals.c_eval);
-        transcript.append(b"d_eval", &evaluations.proof.wire_evals.d_eval);
+        transcript.append(b"a_eval", &evaluations.wire_evals.a_eval);
+        transcript.append(b"b_eval", &evaluations.wire_evals.b_eval);
+        transcript.append(b"c_eval", &evaluations.wire_evals.c_eval);
+        transcript.append(b"d_eval", &evaluations.wire_evals.d_eval);
 
         // TODO Decide if arith_selector should be custom
-        transcript.append(b"q_arith_eval", &evaluations.proof.q_arith_eval);
+        transcript.append(b"q_arith_eval", &evaluations.q_arith_eval);
 
         // Second permutation evals
-        transcript.append(
-            b"left_sig_eval",
-            &evaluations.proof.perm_evals.left_sigma_eval,
-        );
+        transcript
+            .append(b"left_sig_eval", &evaluations.perm_evals.left_sigma_eval);
         transcript.append(
             b"right_sig_eval",
-            &evaluations.proof.perm_evals.right_sigma_eval,
+            &evaluations.perm_evals.right_sigma_eval,
         );
-        transcript.append(
-            b"out_sig_eval",
-            &evaluations.proof.perm_evals.out_sigma_eval,
-        );
-        transcript.append(
-            b"perm_eval",
-            &evaluations.proof.perm_evals.permutation_eval,
-        );
+        transcript
+            .append(b"out_sig_eval", &evaluations.perm_evals.out_sigma_eval);
+        transcript
+            .append(b"perm_eval", &evaluations.perm_evals.permutation_eval);
 
         // Third, all evals needed for custom gates
         evaluations
-            .proof
             .custom_evals
             .vals
             .iter()
@@ -496,7 +489,7 @@ where
             t_4_comm: t_commits[3].commitment().clone(),
             aw_opening,
             saw_opening,
-            evaluations: evaluations.proof,
+            evaluations,
         })
     }
 

--- a/plonk-core/src/proof_system/prover.rs
+++ b/plonk-core/src/proof_system/prover.rs
@@ -123,27 +123,6 @@ where
         )
     }
 
-    // TODO: no longer needed, eliminate
-    /// Computes the quotient Opening [`DensePolynomial`].
-    // fn compute_quotient_opening_poly(
-    //     n: usize,
-    //     t_1_poly: &DensePolynomial<F>,
-    //     t_2_poly: &DensePolynomial<F>,
-    //     t_3_poly: &DensePolynomial<F>,
-    //     t_4_poly: &DensePolynomial<F>,
-    //     z_challenge: &F,
-    // ) -> DensePolynomial<F> {
-    //     // Compute z^n , z^2n , z^3n
-    //     let z_n = z_challenge.pow(&[n as u64, 0, 0, 0]);
-    //     let z_two_n = z_challenge.pow(&[2 * n as u64, 0, 0, 0]);
-    //     let z_three_n = z_challenge.pow(&[3 * n as u64, 0, 0, 0]);
-    //     let a = t_1_poly;
-    //     let b = t_2_poly * z_n;
-    //     let c = t_3_poly * z_two_n;
-    //     let d = t_4_poly * z_three_n;
-    //     a + &b + c + d
-    // }
-
     /// Convert variables to their actual witness values.
     fn to_scalars(&self, vars: &[Variable]) -> Vec<F> {
         vars.iter().map(|var| self.cs.variables[var]).collect()
@@ -454,16 +433,6 @@ where
         //
         // We merge the quotient polynomial using the `z_challenge` so the SRS
         // is linear in the circuit size `n`
-
-        //TODO eliminate this
-        // let quot = Self::compute_quotient_opening_poly(
-        //     n,
-        //     &t_1_poly,
-        //     &t_2_poly,
-        //     &t_3_poly,
-        //     &t_4_poly,
-        //     &z_challenge,
-        // );
 
         // Compute aggregate witness to polynomials evaluated at the evaluation
         // challenge `z`

--- a/plonk-core/src/proof_system/prover.rs
+++ b/plonk-core/src/proof_system/prover.rs
@@ -429,7 +429,6 @@ where
         let aw_challenge: F = transcript.challenge_scalar(b"aggregate_witness");
 
         let aw_polys = [
-            // label_polynomial!(quot),
             label_polynomial!(lin_poly),
             label_polynomial!(prover_key.permutation.left_sigma.0.clone()),
             label_polynomial!(prover_key.permutation.right_sigma.0.clone()),

--- a/plonk-core/src/proof_system/prover.rs
+++ b/plonk-core/src/proof_system/prover.rs
@@ -441,7 +441,7 @@ where
             .custom_evals
             .vals
             .iter()
-            .map(|(label, eval)| {
+            .for_each(|(label, eval)| {
                 let static_label = Box::leak(label.to_owned().into_boxed_str());
                 transcript.append(static_label.as_bytes(), eval);
             });

--- a/plonk-core/src/proof_system/quotient_poly.rs
+++ b/plonk-core/src/proof_system/quotient_poly.rs
@@ -196,14 +196,14 @@ where
                 prover_key.range_selector.1[i],
                 range_challenge,
                 wit_vals,
-                RangeVals::from_evaluations(custom_vals),
+                RangeVals::from_evaluations(&custom_vals),
             );
 
             let logic = Logic::quotient_term(
                 prover_key.logic_selector.1[i],
                 logic_challenge,
                 wit_vals,
-                LogicVals::from_evaluations(custom_vals),
+                LogicVals::from_evaluations(&custom_vals),
             );
 
             let fixed_base_scalar_mul =
@@ -211,14 +211,14 @@ where
                     prover_key.fixed_group_add_selector.1[i],
                     fixed_base_challenge,
                     wit_vals,
-                    FBSMVals::from_evaluations(custom_vals),
+                    FBSMVals::from_evaluations(&custom_vals),
                 );
 
             let curve_addition = CurveAddition::<_, P>::quotient_term(
                 prover_key.variable_group_add_selector.1[i],
                 var_base_challenge,
                 wit_vals,
-                CAVals::from_evaluations(custom_vals),
+                CAVals::from_evaluations(&custom_vals),
             );
 
             (arithmetic + pi_eval_8n[i])

--- a/plonk-core/src/proof_system/quotient_poly.rs
+++ b/plonk-core/src/proof_system/quotient_poly.rs
@@ -11,7 +11,7 @@ use crate::{
         logic::Logic,
         range::Range,
         widget::GateConstraint,
-        GateValues, ProverKey,
+        ProverKey,
     },
 };
 use ark_ec::TEModelParameters;
@@ -19,6 +19,14 @@ use ark_ff::{FftField, PrimeField};
 use ark_poly::{
     univariate::DensePolynomial, EvaluationDomain, GeneralEvaluationDomain,
     UVPolynomial,
+};
+
+use super::{
+    ecc::{CAVals, FBSMVals},
+    linearisation_poly::CustomEvaluations,
+    logic::LogicVals,
+    range::RangeVals,
+    CustomValues, WitnessValues,
 };
 
 /// Computes the Quotient [`DensePolynomial`] given the [`EvaluationDomain`], a
@@ -133,7 +141,8 @@ where
     ))
 }
 
-/// Ensures that the gate constraints are satisfied.
+/// Computes contribution to the quotient polynomial that ensures
+/// the gate constraints are satisfied.
 fn compute_gate_constraint_satisfiability<F, P>(
     domain: &GeneralEvaluationDomain<F>,
     range_challenge: F,
@@ -159,52 +168,57 @@ where
     })?;
     let pi_eval_8n = domain_8n.coset_fft(pi_poly);
 
+    // TODO Eliminate contribution of unused gates
     Ok((0..domain_8n.size())
         .map(|i| {
-            let values = GateValues {
-                left: wl_eval_8n[i],
-                right: wr_eval_8n[i],
-                output: wo_eval_8n[i],
-                fourth: w4_eval_8n[i],
-                left_next: wl_eval_8n[i + 8],
-                right_next: wr_eval_8n[i + 8],
-                fourth_next: w4_eval_8n[i + 8],
-                left_selector: prover_key.arithmetic.q_l.1[i],
-                right_selector: prover_key.arithmetic.q_r.1[i],
-                constant_selector: prover_key.arithmetic.q_c.1[i],
+            let wit_vals = WitnessValues {
+                a_val: wl_eval_8n[i],
+                b_val: wr_eval_8n[i],
+                c_val: wo_eval_8n[i],
+                d_val: w4_eval_8n[i],
             };
 
-            let arithmetic = prover_key.arithmetic.compute_quotient_i(
-                i,
-                values.left,
-                values.right,
-                values.output,
-                values.fourth,
-            );
+            let custom_vals = CustomEvaluations {
+                vals: vec![
+                    ("a_next_eval".to_string(), wl_eval_8n[i + 8]),
+                    ("b_next_eval".to_string(), wr_eval_8n[i + 8]),
+                    ("d_next_eval".to_string(), w4_eval_8n[i + 8]),
+                    ("q_l_eval".to_string(), prover_key.arithmetic.q_l.1[i]),
+                    ("q_r_eval".to_string(), prover_key.arithmetic.q_r.1[i]),
+                    ("q_c_eval".to_string(), prover_key.arithmetic.q_c.1[i]),
+                ],
+            };
+
+            let arithmetic =
+                prover_key.arithmetic.compute_quotient_i(i, wit_vals);
 
             let range = Range::quotient_term(
                 prover_key.range_selector.1[i],
                 range_challenge,
-                values,
+                wit_vals,
+                RangeVals::from_evaluations(custom_vals),
             );
 
             let logic = Logic::quotient_term(
                 prover_key.logic_selector.1[i],
                 logic_challenge,
-                values,
+                wit_vals,
+                LogicVals::from_evaluations(custom_vals),
             );
 
             let fixed_base_scalar_mul =
                 FixedBaseScalarMul::<_, P>::quotient_term(
                     prover_key.fixed_group_add_selector.1[i],
                     fixed_base_challenge,
-                    values,
+                    wit_vals,
+                    FBSMVals::from_evaluations(custom_vals),
                 );
 
             let curve_addition = CurveAddition::<_, P>::quotient_term(
                 prover_key.variable_group_add_selector.1[i],
                 var_base_challenge,
-                values,
+                wit_vals,
+                CAVals::from_evaluations(custom_vals),
             );
 
             (arithmetic + pi_eval_8n[i])
@@ -231,7 +245,7 @@ fn compute_permutation_checks<F>(
     gamma: F,
 ) -> Result<Vec<F>, Error>
 where
-    F: FftField,
+    F: PrimeField,
 {
     let domain_8n = GeneralEvaluationDomain::<F>::new(8 * domain.size())
         .ok_or(Error::InvalidEvalDomainSize {

--- a/plonk-core/src/proof_system/widget/arithmetic.rs
+++ b/plonk-core/src/proof_system/widget/arithmetic.rs
@@ -134,19 +134,23 @@ where
     ) {
         let q_arith_eval = evaluations.q_arith_eval;
 
-        scalars.push(evaluations.a_eval * evaluations.b_eval * q_arith_eval);
+        scalars.push(
+            evaluations.wire_evals.a_eval
+                * evaluations.wire_evals.b_eval
+                * q_arith_eval,
+        );
         points.push(self.q_m.clone());
 
-        scalars.push(evaluations.a_eval * q_arith_eval);
+        scalars.push(evaluations.wire_evals.a_eval * q_arith_eval);
         points.push(self.q_l.clone());
 
-        scalars.push(evaluations.b_eval * q_arith_eval);
+        scalars.push(evaluations.wire_evals.b_eval * q_arith_eval);
         points.push(self.q_r.clone());
 
-        scalars.push(evaluations.c_eval * q_arith_eval);
+        scalars.push(evaluations.wire_evals.c_eval * q_arith_eval);
         points.push(self.q_o.clone());
 
-        scalars.push(evaluations.d_eval * q_arith_eval);
+        scalars.push(evaluations.wire_evals.d_eval * q_arith_eval);
         points.push(self.q_4.clone());
 
         scalars.push(q_arith_eval);

--- a/plonk-core/src/proof_system/widget/arithmetic.rs
+++ b/plonk-core/src/proof_system/widget/arithmetic.rs
@@ -7,12 +7,11 @@
 //! Arithmetic Gates
 
 use crate::proof_system::linearisation_poly::ProofEvaluations;
+use crate::proof_system::WitnessValues;
 use ark_ff::{FftField, PrimeField};
 use ark_poly::{polynomial::univariate::DensePolynomial, Evaluations};
 use ark_poly_commit::PolynomialCommitment;
 use ark_serialize::*;
-
-use super::WitnessValues;
 
 /// Arithmetic Gates Prover Key
 #[derive(CanonicalDeserialize, CanonicalSerialize, derivative::Derivative)]

--- a/plonk-core/src/proof_system/widget/arithmetic.rs
+++ b/plonk-core/src/proof_system/widget/arithmetic.rs
@@ -132,7 +132,7 @@ where
         points: &mut Vec<PC::Commitment>,
         evaluations: &ProofEvaluations<F>,
     ) {
-        let q_arith_eval = evaluations.q_arith_eval;
+        let q_arith_eval = evaluations.custom_evals.get("q_arith_eval");
 
         scalars.push(
             evaluations.wire_evals.a_eval

--- a/plonk-core/src/proof_system/widget/arithmetic.rs
+++ b/plonk-core/src/proof_system/widget/arithmetic.rs
@@ -12,6 +12,8 @@ use ark_poly::{polynomial::univariate::DensePolynomial, Evaluations};
 use ark_poly_commit::PolynomialCommitment;
 use ark_serialize::*;
 
+use super::WitnessValues;
+
 /// Arithmetic Gates Prover Key
 #[derive(CanonicalDeserialize, CanonicalSerialize, derivative::Derivative)]
 #[derivative(Clone, Debug, Eq, PartialEq)]
@@ -43,23 +45,20 @@ where
 
 impl<F> ProverKey<F>
 where
-    F: FftField,
+    F: PrimeField,
 {
     /// Computes the arithmetic gate contribution to the quotient polynomial at
     /// the element of the domain at the given `index`.
     pub fn compute_quotient_i(
         &self,
         index: usize,
-        w_l_i: F,
-        w_r_i: F,
-        w_o_i: F,
-        w_4_i: F,
+        wit_vals: WitnessValues<F>,
     ) -> F {
-        ((w_l_i * w_r_i * self.q_m.1[index])
-            + (w_l_i * self.q_l.1[index])
-            + (w_r_i * self.q_r.1[index])
-            + (w_o_i * self.q_o.1[index])
-            + (w_4_i * self.q_4.1[index])
+        ((wit_vals.a_val * wit_vals.b_val * self.q_m.1[index])
+            + (wit_vals.a_val * self.q_l.1[index])
+            + (wit_vals.b_val * self.q_r.1[index])
+            + (wit_vals.c_val * self.q_o.1[index])
+            + (wit_vals.d_val * self.q_4.1[index])
             + self.q_c.1[index])
             * self.q_arith.1[index]
     }

--- a/plonk-core/src/proof_system/widget/ecc/curve_addition.rs
+++ b/plonk-core/src/proof_system/widget/ecc/curve_addition.rs
@@ -15,12 +15,16 @@ use ark_ec::{ModelParameters, TEModelParameters};
 use ark_ff::PrimeField;
 use core::marker::PhantomData;
 
+/// Values needed for the computation of the Curve Addition gate constraint.
 pub struct CAVals<F>
 where
     F: PrimeField,
 {
+    /// Left wire value in the next position
     pub a_next_val: F,
+    /// Right wire value in the next position
     pub b_next_val: F,
+    /// Fourth wire value in the next position
     pub d_next_val: F,
 }
 

--- a/plonk-core/src/proof_system/widget/ecc/curve_addition.rs
+++ b/plonk-core/src/proof_system/widget/ecc/curve_addition.rs
@@ -28,7 +28,7 @@ impl<F> CustomValues<F> for CAVals<F>
 where
     F: PrimeField,
 {
-    fn from_evaluations(custom_evals: CustomEvaluations<F>) -> Self {
+    fn from_evaluations(custom_evals: &CustomEvaluations<F>) -> Self {
         let a_next_val = custom_evals.get("a_next_eval");
         let b_next_val = custom_evals.get("b_next_eval");
         let d_next_val = custom_evals.get("d_next_eval");

--- a/plonk-core/src/proof_system/widget/ecc/curve_addition.rs
+++ b/plonk-core/src/proof_system/widget/ecc/curve_addition.rs
@@ -6,13 +6,10 @@
 
 //! Elliptic Curve Point Addition Gate
 
-use crate::{
-    get_label,
-    proof_system::{
-        linearisation_poly::CustomEvaluations,
-        widget::{GateConstraint, WitnessValues},
-        CustomValues,
-    },
+use crate::proof_system::{
+    linearisation_poly::CustomEvaluations,
+    widget::{GateConstraint, WitnessValues},
+    CustomValues,
 };
 use ark_ec::{ModelParameters, TEModelParameters};
 use ark_ff::PrimeField;
@@ -22,9 +19,9 @@ pub struct CAVals<F>
 where
     F: PrimeField,
 {
-    pub a_next_eval: F,
-    pub b_next_eval: F,
-    pub d_next_eval: F,
+    pub a_next_val: F,
+    pub b_next_val: F,
+    pub d_next_val: F,
 }
 
 impl<F> CustomValues<F> for CAVals<F>
@@ -32,13 +29,13 @@ where
     F: PrimeField,
 {
     fn from_evaluations(custom_evals: CustomEvaluations<F>) -> Self {
-        let a_next_eval = custom_evals.get(get_label!(a_next_eval));
-        let b_next_eval = custom_evals.get(get_label!(b_next_eval));
-        let d_next_eval = custom_evals.get(get_label!(d_next_eval));
+        let a_next_val = custom_evals.get("a_next_eval");
+        let b_next_val = custom_evals.get("b_next_eval");
+        let d_next_val = custom_evals.get("d_next_eval");
         CAVals {
-            a_next_eval,
-            b_next_eval,
-            d_next_eval,
+            a_next_val,
+            b_next_val,
+            d_next_val,
         }
     }
 }
@@ -63,13 +60,13 @@ where
         wit_vals: WitnessValues<F>,
         custom_vals: Self::CustomVals,
     ) -> F {
-        let x_1 = wit_vals.a_eval;
-        let x_3 = custom_vals.a_next_eval;
-        let y_1 = wit_vals.r_eval;
-        let y_3 = custom_vals.b_next_eval;
-        let x_2 = wit_vals.c_eval;
-        let y_2 = wit_vals.d_eval;
-        let x1_y2 = custom_vals.d_next_eval;
+        let x_1 = wit_vals.a_val;
+        let x_3 = custom_vals.a_next_val;
+        let y_1 = wit_vals.b_val;
+        let y_3 = custom_vals.b_next_val;
+        let x_2 = wit_vals.c_val;
+        let y_2 = wit_vals.d_val;
+        let x1_y2 = custom_vals.d_next_val;
 
         let kappa = separation_challenge.square();
 

--- a/plonk-core/src/proof_system/widget/ecc/curve_addition.rs
+++ b/plonk-core/src/proof_system/widget/ecc/curve_addition.rs
@@ -6,9 +6,13 @@
 
 //! Elliptic Curve Point Addition Gate
 
-use crate::proof_system::{
-    widget::{GateConstraint, WitnessValues},
-    CustomValues,
+use crate::{
+    get_label,
+    proof_system::{
+        linearisation_poly::CustomEvaluations,
+        widget::{GateConstraint, WitnessValues},
+        CustomValues,
+    },
 };
 use ark_ec::{ModelParameters, TEModelParameters};
 use ark_ff::PrimeField;
@@ -18,15 +22,26 @@ pub struct CAVals<F>
 where
     F: PrimeField,
 {
-    pub left_next: F,
-    pub right_next: F,
-    pub fourth_next: F,
-    pub left_selector: F,
-    pub right_selector: F,
-    pub constant_selector: F,
+    pub a_next_eval: F,
+    pub b_next_eval: F,
+    pub d_next_eval: F,
 }
 
-impl<F> CustomValues<F> for CAVals<F> where F: PrimeField {}
+impl<F> CustomValues<F> for CAVals<F>
+where
+    F: PrimeField,
+{
+    fn from_evaluations(custom_evals: CustomEvaluations<F>) -> Self {
+        let a_next_eval = custom_evals.get(get_label!(a_next_eval));
+        let b_next_eval = custom_evals.get(get_label!(b_next_eval));
+        let d_next_eval = custom_evals.get(get_label!(d_next_eval));
+        CAVals {
+            a_next_eval,
+            b_next_eval,
+            d_next_eval,
+        }
+    }
+}
 
 /// Curve Addition Gate
 #[derive(derivative::Derivative)]
@@ -48,13 +63,13 @@ where
         wit_vals: WitnessValues<F>,
         custom_vals: Self::CustomVals,
     ) -> F {
-        let x_1 = wit_vals.left;
-        let x_3 = custom_vals.left_next;
-        let y_1 = wit_vals.right;
-        let y_3 = custom_vals.right_next;
-        let x_2 = wit_vals.output;
-        let y_2 = wit_vals.fourth;
-        let x1_y2 = custom_vals.fourth_next;
+        let x_1 = wit_vals.a_eval;
+        let x_3 = custom_vals.a_next_eval;
+        let y_1 = wit_vals.r_eval;
+        let y_3 = custom_vals.b_next_eval;
+        let x_2 = wit_vals.c_eval;
+        let y_2 = wit_vals.d_eval;
+        let x1_y2 = custom_vals.d_next_eval;
 
         let kappa = separation_challenge.square();
 

--- a/plonk-core/src/proof_system/widget/ecc/curve_addition.rs
+++ b/plonk-core/src/proof_system/widget/ecc/curve_addition.rs
@@ -6,10 +6,27 @@
 
 //! Elliptic Curve Point Addition Gate
 
-use crate::proof_system::widget::{GateConstraint, GateValues};
+use crate::proof_system::{
+    widget::{GateConstraint, WitnessValues},
+    CustomValues,
+};
 use ark_ec::{ModelParameters, TEModelParameters};
 use ark_ff::PrimeField;
 use core::marker::PhantomData;
+
+pub struct CAVals<F>
+where
+    F: PrimeField,
+{
+    pub left_next: F,
+    pub right_next: F,
+    pub fourth_next: F,
+    pub left_selector: F,
+    pub right_selector: F,
+    pub constant_selector: F,
+}
+
+impl<F> CustomValues<F> for CAVals<F> where F: PrimeField {}
 
 /// Curve Addition Gate
 #[derive(derivative::Derivative)]
@@ -24,15 +41,20 @@ where
     F: PrimeField,
     P: TEModelParameters<BaseField = F>,
 {
+    type CustomVals = CAVals<F>;
     #[inline]
-    fn constraints(separation_challenge: F, values: GateValues<F>) -> F {
-        let x_1 = values.left;
-        let x_3 = values.left_next;
-        let y_1 = values.right;
-        let y_3 = values.right_next;
-        let x_2 = values.output;
-        let y_2 = values.fourth;
-        let x1_y2 = values.fourth_next;
+    fn constraints(
+        separation_challenge: F,
+        wit_vals: WitnessValues<F>,
+        custom_vals: Self::CustomVals,
+    ) -> F {
+        let x_1 = wit_vals.left;
+        let x_3 = custom_vals.left_next;
+        let y_1 = wit_vals.right;
+        let y_3 = custom_vals.right_next;
+        let x_2 = wit_vals.output;
+        let y_2 = wit_vals.fourth;
+        let x1_y2 = custom_vals.fourth_next;
 
         let kappa = separation_challenge.square();
 

--- a/plonk-core/src/proof_system/widget/ecc/fixed_base_scalar_mul.rs
+++ b/plonk-core/src/proof_system/widget/ecc/fixed_base_scalar_mul.rs
@@ -27,15 +27,23 @@ use ark_ec::{ModelParameters, TEModelParameters};
 use ark_ff::PrimeField;
 use core::marker::PhantomData;
 
+/// Values needed for the computation of the Fixed Base Multiplication gate
+/// constraint.
 pub struct FBSMVals<F>
 where
     F: PrimeField,
 {
+    /// Left wire value in the next position
     pub a_next_val: F,
+    /// Right wire value in the next position
     pub b_next_val: F,
+    /// Fourth wire value in the next position
     pub d_next_val: F,
+    /// Left selector value
     pub q_l_val: F,
+    /// Right selector value
     pub q_r_val: F,
+    /// Constant selector value
     pub q_c_val: F,
 }
 

--- a/plonk-core/src/proof_system/widget/ecc/fixed_base_scalar_mul.rs
+++ b/plonk-core/src/proof_system/widget/ecc/fixed_base_scalar_mul.rs
@@ -43,7 +43,7 @@ impl<F> CustomValues<F> for FBSMVals<F>
 where
     F: PrimeField,
 {
-    fn from_evaluations(custom_evals: CustomEvaluations<F>) -> Self {
+    fn from_evaluations(custom_evals: &CustomEvaluations<F>) -> Self {
         let a_next_val = custom_evals.get("a_next_eval");
         let b_next_val = custom_evals.get("b_next_eval");
         let d_next_val = custom_evals.get("d_next_eval");

--- a/plonk-core/src/proof_system/widget/ecc/fixed_base_scalar_mul.rs
+++ b/plonk-core/src/proof_system/widget/ecc/fixed_base_scalar_mul.rs
@@ -27,7 +27,7 @@ use ark_ec::{ModelParameters, TEModelParameters};
 use ark_ff::PrimeField;
 use core::marker::PhantomData;
 
-pub struct FSMVals<F>
+pub struct FBSMVals<F>
 where
     F: PrimeField,
 {
@@ -39,7 +39,7 @@ where
     pub q_c_val: F,
 }
 
-impl<F> CustomValues<F> for FSMVals<F>
+impl<F> CustomValues<F> for FBSMVals<F>
 where
     F: PrimeField,
 {
@@ -50,7 +50,7 @@ where
         let q_l_val = custom_evals.get("q_l_eval");
         let q_r_val = custom_evals.get("q_r_eval");
         let q_c_val = custom_evals.get("q_c_eval");
-        FSMVals {
+        FBSMVals {
             a_next_val,
             b_next_val,
             d_next_val,
@@ -74,7 +74,7 @@ where
     F: PrimeField,
     P: TEModelParameters<BaseField = F>,
 {
-    type CustomVals = FSMVals<F>;
+    type CustomVals = FBSMVals<F>;
 
     #[inline]
     fn constraints(

--- a/plonk-core/src/proof_system/widget/ecc/fixed_base_scalar_mul.rs
+++ b/plonk-core/src/proof_system/widget/ecc/fixed_base_scalar_mul.rs
@@ -18,13 +18,10 @@
 //! Bits are accumulated in base2. So we use d(Xw) - 2d(X) to extract the
 //! base2 bit.
 
-use crate::{
-    get_label,
-    proof_system::{
-        linearisation_poly::CustomEvaluations,
-        widget::{GateConstraint, WitnessValues},
-        CustomValues,
-    },
+use crate::proof_system::{
+    linearisation_poly::CustomEvaluations,
+    widget::{GateConstraint, WitnessValues},
+    CustomValues,
 };
 use ark_ec::{ModelParameters, TEModelParameters};
 use ark_ff::PrimeField;
@@ -34,12 +31,12 @@ pub struct FSMVals<F>
 where
     F: PrimeField,
 {
-    pub a_next_eval: F,
-    pub b_next_eval: F,
-    pub d_next_eval: F,
-    pub q_l_eval: F,
-    pub q_r_eval: F,
-    pub q_c_eval: F,
+    pub a_next_val: F,
+    pub b_next_val: F,
+    pub d_next_val: F,
+    pub q_l_val: F,
+    pub q_r_val: F,
+    pub q_c_val: F,
 }
 
 impl<F> CustomValues<F> for FSMVals<F>
@@ -47,19 +44,19 @@ where
     F: PrimeField,
 {
     fn from_evaluations(custom_evals: CustomEvaluations<F>) -> Self {
-        let a_next_eval = custom_evals.get(get_label!(a_next_eval));
-        let b_next_eval = custom_evals.get(get_label!(b_next_eval));
-        let d_next_eval = custom_evals.get(get_label!(d_next_eval));
-        let q_l_eval = custom_evals.get(get_label!(q_l_eval));
-        let q_r_eval = custom_evals.get(get_label!(q_r_eval));
-        let q_c_eval = custom_evals.get(get_label!(q_c_eval));
+        let a_next_val = custom_evals.get("a_next_eval");
+        let b_next_val = custom_evals.get("b_next_eval");
+        let d_next_val = custom_evals.get("d_next_eval");
+        let q_l_val = custom_evals.get("q_l_eval");
+        let q_r_val = custom_evals.get("q_r_eval");
+        let q_c_val = custom_evals.get("q_c_eval");
         FSMVals {
-            a_next_eval,
-            b_next_eval,
-            d_next_eval,
-            q_l_eval,
-            q_r_eval,
-            q_c_eval,
+            a_next_val,
+            b_next_val,
+            d_next_val,
+            q_l_val,
+            q_r_val,
+            q_c_val,
         }
     }
 }
@@ -89,18 +86,18 @@ where
         let kappa_sq = kappa.square();
         let kappa_cu = kappa_sq * kappa;
 
-        let x_beta_eval = custom_vals.q_l_eval;
-        let y_beta_eval = custom_vals.q_r_eval;
+        let x_beta_eval = custom_vals.q_l_val;
+        let y_beta_eval = custom_vals.q_r_val;
 
-        let acc_x = wit_vals.a_eval;
-        let acc_x_next = custom_vals.a_next_eval;
-        let acc_y = wit_vals.r_eval;
-        let acc_y_next = custom_vals.b_next_eval;
+        let acc_x = wit_vals.a_val;
+        let acc_x_next = custom_vals.a_next_val;
+        let acc_y = wit_vals.b_val;
+        let acc_y_next = custom_vals.b_next_val;
 
-        let xy_alpha = wit_vals.c_eval;
+        let xy_alpha = wit_vals.c_val;
 
-        let accumulated_bit = wit_vals.d_eval;
-        let accumulated_bit_next = custom_vals.d_next_eval;
+        let accumulated_bit = wit_vals.d_val;
+        let accumulated_bit_next = custom_vals.d_next_val;
         let bit = extract_bit(accumulated_bit, accumulated_bit_next);
 
         // Check bit consistency
@@ -110,7 +107,7 @@ where
         let x_alpha = x_beta_eval * bit;
 
         // xy_alpha consistency check
-        let xy_consistency = ((bit * custom_vals.q_c_eval) - xy_alpha) * kappa;
+        let xy_consistency = ((bit * custom_vals.q_c_val) - xy_alpha) * kappa;
 
         // x accumulator consistency check
         let x_3 = acc_x_next;

--- a/plonk-core/src/proof_system/widget/logic.rs
+++ b/plonk-core/src/proof_system/widget/logic.rs
@@ -6,8 +6,19 @@
 
 //! Logic Gates
 
+<<<<<<< HEAD
 use crate::proof_system::widget::{GateConstraint, WitnessValues};
 use ark_ff::PrimeField;
+=======
+use crate::{
+    get_label,
+    proof_system::{
+        linearisation_poly::CustomEvaluations,
+        widget::{GateConstraint, WitnessValues},
+    },
+};
+use ark_ff::Field;
+>>>>>>> 8d683a0 (Add `from_evaluations` constructor)
 use core::marker::PhantomData;
 
 use super::CustomValues;
@@ -16,13 +27,34 @@ pub struct LogicVals<F>
 where
     F: PrimeField,
 {
-    pub left_next: F,
-    pub right_next: F,
-    pub fourth_next: F,
-    pub constant_selector: F,
+    pub a_next_eval: F,
+    pub b_next_eval: F,
+    pub d_next_eval: F,
+    pub q_c_eval: F,
 }
 
+impl<F> CustomValues<F> for LogicVals<F>
+where
+    F: Field,
+{
+    fn from_evaluations(custom_evals: CustomEvaluations<F>) -> Self {
+        let a_next_eval = custom_evals.get(get_label!(a_next_eval));
+        let b_next_eval = custom_evals.get(get_label!(b_next_eval));
+        let d_next_eval = custom_evals.get(get_label!(d_next_eval));
+        let q_c_eval = custom_evals.get(get_label!(q_c_eval));
+        LogicVals {
+            a_next_eval,
+            b_next_eval,
+            d_next_eval,
+            q_c_eval,
+        }
+    }
+}
+
+<<<<<<< HEAD
 impl<F> CustomValues<F> for LogicVals<F> where F: PrimeField {}
+=======
+>>>>>>> 8d683a0 (Add `from_evaluations` constructor)
 /// Logic Gate
 #[derive(derivative::Derivative)]
 #[derivative(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
@@ -48,20 +80,19 @@ where
         let kappa_cu = kappa_sq * kappa;
         let kappa_qu = kappa_cu * kappa;
 
-        let a = custom_vals.left_next - four * wit_vals.left;
+        let a = custom_vals.a_next_eval - four * wit_vals.a_eval;
         let c_0 = delta(a);
 
-        let b = custom_vals.right_next - four * wit_vals.right;
+        let b = custom_vals.b_next_eval - four * wit_vals.r_eval;
         let c_1 = delta(b) * kappa;
 
-        let d = custom_vals.fourth_next - four * wit_vals.fourth;
+        let d = custom_vals.d_next_eval - four * wit_vals.d_eval;
         let c_2 = delta(d) * kappa_sq;
 
-        let w = wit_vals.output;
+        let w = wit_vals.c_eval;
         let c_3 = (w - a * b) * kappa_cu;
 
-        let c_4 =
-            delta_xor_and(a, b, w, d, custom_vals.constant_selector) * kappa_qu;
+        let c_4 = delta_xor_and(a, b, w, d, custom_vals.q_c_eval) * kappa_qu;
 
         (c_0 + c_1 + c_2 + c_3 + c_4) * separation_challenge
     }

--- a/plonk-core/src/proof_system/widget/logic.rs
+++ b/plonk-core/src/proof_system/widget/logic.rs
@@ -15,13 +15,18 @@ use core::marker::PhantomData;
 
 use super::CustomValues;
 
+/// Values needed for the computation of the logic gate constraint.
 pub struct LogicVals<F>
 where
     F: PrimeField,
 {
+    /// Left wire value in the next position
     pub a_next_val: F,
+    /// Right wire value in the next position
     pub b_next_val: F,
+    /// Fourth wire value in the next position
     pub d_next_val: F,
+    /// Constant selector value
     pub q_c_val: F,
 }
 

--- a/plonk-core/src/proof_system/widget/logic.rs
+++ b/plonk-core/src/proof_system/widget/logic.rs
@@ -6,10 +6,23 @@
 
 //! Logic Gates
 
-use crate::proof_system::widget::{GateConstraint, GateValues};
+use crate::proof_system::widget::{GateConstraint, WitnessValues};
 use ark_ff::PrimeField;
 use core::marker::PhantomData;
 
+use super::CustomValues;
+
+pub struct LogicVals<F>
+where
+    F: PrimeField,
+{
+    pub left_next: F,
+    pub right_next: F,
+    pub fourth_next: F,
+    pub constant_selector: F,
+}
+
+impl<F> CustomValues<F> for LogicVals<F> where F: PrimeField {}
 /// Logic Gate
 #[derive(derivative::Derivative)]
 #[derivative(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
@@ -21,28 +34,34 @@ impl<F> GateConstraint<F> for Logic<F>
 where
     F: PrimeField,
 {
+    type CustomVals = LogicVals<F>;
+
     #[inline]
-    fn constraints(separation_challenge: F, values: GateValues<F>) -> F {
+    fn constraints(
+        separation_challenge: F,
+        wit_vals: WitnessValues<F>,
+        custom_vals: Self::CustomVals,
+    ) -> F {
         let four = F::from(4_u64);
         let kappa = separation_challenge.square();
         let kappa_sq = kappa.square();
         let kappa_cu = kappa_sq * kappa;
         let kappa_qu = kappa_cu * kappa;
 
-        let a = values.left_next - four * values.left;
+        let a = custom_vals.left_next - four * wit_vals.left;
         let c_0 = delta(a);
 
-        let b = values.right_next - four * values.right;
+        let b = custom_vals.right_next - four * wit_vals.right;
         let c_1 = delta(b) * kappa;
 
-        let d = values.fourth_next - four * values.fourth;
+        let d = custom_vals.fourth_next - four * wit_vals.fourth;
         let c_2 = delta(d) * kappa_sq;
 
-        let w = values.output;
+        let w = wit_vals.output;
         let c_3 = (w - a * b) * kappa_cu;
 
         let c_4 =
-            delta_xor_and(a, b, w, d, values.constant_selector) * kappa_qu;
+            delta_xor_and(a, b, w, d, custom_vals.constant_selector) * kappa_qu;
 
         (c_0 + c_1 + c_2 + c_3 + c_4) * separation_challenge
     }

--- a/plonk-core/src/proof_system/widget/logic.rs
+++ b/plonk-core/src/proof_system/widget/logic.rs
@@ -6,13 +6,9 @@
 
 //! Logic Gates
 
-use crate::proof_system::widget::{GateConstraint, WitnessValues};
-use crate::{
-    get_label,
-    proof_system::{
-        linearisation_poly::CustomEvaluations,
-        widget::{GateConstraint, WitnessValues},
-    },
+use crate::proof_system::{
+    linearisation_poly::CustomEvaluations,
+    widget::{GateConstraint, WitnessValues},
 };
 use ark_ff::PrimeField;
 use core::marker::PhantomData;
@@ -23,31 +19,31 @@ pub struct LogicVals<F>
 where
     F: PrimeField,
 {
-    pub a_next_eval: F,
-    pub b_next_eval: F,
-    pub d_next_eval: F,
-    pub q_c_eval: F,
+    pub a_next_val: F,
+    pub b_next_val: F,
+    pub d_next_val: F,
+    pub q_c_val: F,
 }
 
 impl<F> CustomValues<F> for LogicVals<F>
 where
-    F: Field,
+    F: PrimeField,
 {
     fn from_evaluations(custom_evals: CustomEvaluations<F>) -> Self {
-        let a_next_eval = custom_evals.get(get_label!(a_next_eval));
-        let b_next_eval = custom_evals.get(get_label!(b_next_eval));
-        let d_next_eval = custom_evals.get(get_label!(d_next_eval));
-        let q_c_eval = custom_evals.get(get_label!(q_c_eval));
+        // TODO: Subsitute labels
+        let a_next_val = custom_evals.get("a_next_eval");
+        let b_next_val = custom_evals.get("b_next_eval");
+        let d_next_val = custom_evals.get("d_next_eval");
+        let q_c_val = custom_evals.get("q_c_eval");
         LogicVals {
-            a_next_eval,
-            b_next_eval,
-            d_next_eval,
-            q_c_eval,
+            a_next_val,
+            b_next_val,
+            d_next_val,
+            q_c_val,
         }
     }
 }
 
-impl<F> CustomValues<F> for LogicVals<F> where F: PrimeField {}
 /// Logic Gate
 #[derive(derivative::Derivative)]
 #[derivative(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
@@ -73,19 +69,19 @@ where
         let kappa_cu = kappa_sq * kappa;
         let kappa_qu = kappa_cu * kappa;
 
-        let a = custom_vals.a_next_eval - four * wit_vals.a_eval;
+        let a = custom_vals.a_next_val - four * wit_vals.a_val;
         let c_0 = delta(a);
 
-        let b = custom_vals.b_next_eval - four * wit_vals.b_eval;
+        let b = custom_vals.b_next_val - four * wit_vals.b_val;
         let c_1 = delta(b) * kappa;
 
-        let d = custom_vals.d_next_eval - four * wit_vals.d_eval;
+        let d = custom_vals.d_next_val - four * wit_vals.d_val;
         let c_2 = delta(d) * kappa_sq;
 
-        let w = wit_vals.c_eval;
+        let w = wit_vals.c_val;
         let c_3 = (w - a * b) * kappa_cu;
 
-        let c_4 = delta_xor_and(a, b, w, d, custom_vals.q_c_eval) * kappa_qu;
+        let c_4 = delta_xor_and(a, b, w, d, custom_vals.q_c_val) * kappa_qu;
 
         (c_0 + c_1 + c_2 + c_3 + c_4) * separation_challenge
     }

--- a/plonk-core/src/proof_system/widget/logic.rs
+++ b/plonk-core/src/proof_system/widget/logic.rs
@@ -9,11 +9,10 @@
 use crate::proof_system::{
     linearisation_poly::CustomEvaluations,
     widget::{GateConstraint, WitnessValues},
+    CustomValues,
 };
 use ark_ff::PrimeField;
 use core::marker::PhantomData;
-
-use super::CustomValues;
 
 /// Values needed for the computation of the logic gate constraint.
 pub struct LogicVals<F>

--- a/plonk-core/src/proof_system/widget/logic.rs
+++ b/plonk-core/src/proof_system/widget/logic.rs
@@ -29,7 +29,7 @@ impl<F> CustomValues<F> for LogicVals<F>
 where
     F: PrimeField,
 {
-    fn from_evaluations(custom_evals: CustomEvaluations<F>) -> Self {
+    fn from_evaluations(custom_evals: &CustomEvaluations<F>) -> Self {
         // TODO: Subsitute labels
         let a_next_val = custom_evals.get("a_next_eval");
         let b_next_val = custom_evals.get("b_next_eval");

--- a/plonk-core/src/proof_system/widget/logic.rs
+++ b/plonk-core/src/proof_system/widget/logic.rs
@@ -83,7 +83,7 @@ where
         let a = custom_vals.a_next_eval - four * wit_vals.a_eval;
         let c_0 = delta(a);
 
-        let b = custom_vals.b_next_eval - four * wit_vals.r_eval;
+        let b = custom_vals.b_next_eval - four * wit_vals.b_eval;
         let c_1 = delta(b) * kappa;
 
         let d = custom_vals.d_next_eval - four * wit_vals.d_eval;

--- a/plonk-core/src/proof_system/widget/logic.rs
+++ b/plonk-core/src/proof_system/widget/logic.rs
@@ -6,10 +6,7 @@
 
 //! Logic Gates
 
-<<<<<<< HEAD
 use crate::proof_system::widget::{GateConstraint, WitnessValues};
-use ark_ff::PrimeField;
-=======
 use crate::{
     get_label,
     proof_system::{
@@ -17,8 +14,7 @@ use crate::{
         widget::{GateConstraint, WitnessValues},
     },
 };
-use ark_ff::Field;
->>>>>>> 8d683a0 (Add `from_evaluations` constructor)
+use ark_ff::PrimeField;
 use core::marker::PhantomData;
 
 use super::CustomValues;
@@ -51,10 +47,7 @@ where
     }
 }
 
-<<<<<<< HEAD
 impl<F> CustomValues<F> for LogicVals<F> where F: PrimeField {}
-=======
->>>>>>> 8d683a0 (Add `from_evaluations` constructor)
 /// Logic Gate
 #[derive(derivative::Derivative)]
 #[derivative(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]

--- a/plonk-core/src/proof_system/widget/mod.rs
+++ b/plonk-core/src/proof_system/widget/mod.rs
@@ -41,16 +41,16 @@ where
     F: PrimeField,
 {
     /// Left Value
-    pub a_eval: F,
+    pub a_val: F,
 
     /// Right Value
-    pub b_eval: F,
+    pub b_val: F,
 
     /// Output Value
-    pub c_eval: F,
+    pub c_val: F,
 
     /// Fourth Value
-    pub d_eval: F,
+    pub d_val: F,
 }
 
 /// Gate Constraint
@@ -113,10 +113,10 @@ where
         let coefficient = Self::constraints(
             separation_challenge,
             WitnessValues {
-                a_eval: evaluations.wire_evals.a_eval,
-                b_eval: evaluations.wire_evals.b_eval,
-                c_eval: evaluations.wire_evals.c_eval,
-                d_eval: evaluations.wire_evals.d_eval,
+                a_val: evaluations.wire_evals.a_eval,
+                b_val: evaluations.wire_evals.b_eval,
+                c_val: evaluations.wire_evals.c_eval,
+                d_val: evaluations.wire_evals.d_eval,
             },
             // TODO
             custom_vals,

--- a/plonk-core/src/proof_system/widget/mod.rs
+++ b/plonk-core/src/proof_system/widget/mod.rs
@@ -28,7 +28,7 @@ pub trait CustomValues<F>
 where
     F: PrimeField,
 {
-    fn from_evaluations(custom_evals: CustomEvaluations<F>) -> Self;
+    fn from_evaluations(custom_evals: &CustomEvaluations<F>) -> Self;
 }
 
 /// Witness Values
@@ -58,7 +58,7 @@ pub trait GateConstraint<F>
 where
     F: PrimeField,
 {
-    type CustomVals;
+    type CustomVals: CustomValues<F>;
 
     /// Returns the coefficient of the quotient polynomial for this gate given
     /// an instantiation of the gate at `values` and a
@@ -118,15 +118,7 @@ where
                 c_val: evaluations.wire_evals.c_eval,
                 d_val: evaluations.wire_evals.d_eval,
             },
-            // TODO
-            custom_vals,
-            /* left_next: evaluations.a_next_eval,
-             * right_next: evaluations.b_next_eval,
-             * fourth_next: evaluations.d_next_eval,
-             * left_selector: evaluations.q_l_eval,
-             * right_selector: evaluations.q_r_eval,
-             * constant_selector: evaluations.q_c_eval,
-             * }, */
+            Self::CustomVals::from_evaluations(&evaluations.custom_evals),
         );
         scalars.push(coefficient);
         points.push(selector_commitment.clone());

--- a/plonk-core/src/proof_system/widget/mod.rs
+++ b/plonk-core/src/proof_system/widget/mod.rs
@@ -13,14 +13,15 @@ pub mod range;
 
 use crate::{
     commitment::HomomorphicCommitment,
-    proof_system::{linearisation_poly::ProofEvaluations, permutation},
+    proof_system::{
+        linearisation_poly::CustomEvaluations,
+        linearisation_poly::ProofEvaluations, permutation,
+    },
     transcript::TranscriptProtocol,
 };
 use ark_ff::PrimeField;
 use ark_poly::{univariate::DensePolynomial, Evaluations};
 use ark_serialize::*;
-
-use super::linearisation_poly::CustomEvaluations;
 
 /// Set of values needed for a custom gate
 pub trait CustomValues<F>

--- a/plonk-core/src/proof_system/widget/mod.rs
+++ b/plonk-core/src/proof_system/widget/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     proof_system::{linearisation_poly::ProofEvaluations, permutation},
     transcript::TranscriptProtocol,
 };
-use ark_ff::{FftField, PrimeField};
+use ark_ff::PrimeField;
 use ark_poly::{univariate::DensePolynomial, Evaluations};
 use ark_serialize::*;
 
@@ -279,7 +279,7 @@ where
 )]
 pub struct ProverKey<F>
 where
-    F: FftField,
+    F: PrimeField,
 {
     /// Circuit size
     pub(crate) n: usize,
@@ -314,7 +314,7 @@ where
 
 impl<F> ProverKey<F>
 where
-    F: FftField,
+    F: PrimeField,
 {
     pub(crate) fn v_h_coset_8n(&self) -> &Evaluations<F> {
         &self.v_h_coset_8n
@@ -383,7 +383,7 @@ mod test {
 
     fn rand_poly_eval<F>(n: usize) -> (DensePolynomial<F>, Evaluations<F>)
     where
-        F: FftField,
+        F: PrimeField,
     {
         let polynomial = DensePolynomial::rand(n, &mut OsRng);
         (polynomial, rand_evaluations(n))
@@ -391,7 +391,7 @@ mod test {
 
     fn rand_evaluations<F>(n: usize) -> Evaluations<F>
     where
-        F: FftField,
+        F: PrimeField,
     {
         let domain = GeneralEvaluationDomain::new(4 * n).unwrap();
         let values: Vec<_> = (0..8 * n).map(|_| F::rand(&mut OsRng)).collect();

--- a/plonk-core/src/proof_system/widget/mod.rs
+++ b/plonk-core/src/proof_system/widget/mod.rs
@@ -22,12 +22,13 @@ use ark_serialize::*;
 
 use super::linearisation_poly::CustomEvaluations;
 
-/// Constructs gate-specific values struct from the set of evaluations
-/// `CustomEvaluations`
+/// Set of values needed for a custom gate
 pub trait CustomValues<F>
 where
     F: PrimeField,
 {
+    /// Constructs gate-specific values struct from the set of evaluations
+    /// `CustomEvaluations`
     fn from_evaluations(custom_evals: &CustomEvaluations<F>) -> Self;
 }
 
@@ -58,6 +59,7 @@ pub trait GateConstraint<F>
 where
     F: PrimeField,
 {
+    /// Custom values needed for the gate
     type CustomVals: CustomValues<F>;
 
     /// Returns the coefficient of the quotient polynomial for this gate given

--- a/plonk-core/src/proof_system/widget/mod.rs
+++ b/plonk-core/src/proof_system/widget/mod.rs
@@ -20,10 +20,15 @@ use ark_ff::{FftField, PrimeField};
 use ark_poly::{univariate::DensePolynomial, Evaluations};
 use ark_serialize::*;
 
+use super::linearisation_poly::CustomEvaluations;
+
+/// Constructs gate-specific values struct from the set of evaluations
+/// `CustomEvaluations`
 pub trait CustomValues<F>
 where
     F: PrimeField,
 {
+    fn from_evaluations(custom_evals: CustomEvaluations<F>) -> Self;
 }
 
 /// Witness Values
@@ -36,16 +41,16 @@ where
     F: PrimeField,
 {
     /// Left Value
-    pub left: F,
+    pub a_eval: F,
 
     /// Right Value
-    pub right: F,
+    pub b_eval: F,
 
     /// Output Value
-    pub output: F,
+    pub c_eval: F,
 
     /// Fourth Value
-    pub fourth: F,
+    pub d_eval: F,
 }
 
 /// Gate Constraint
@@ -108,10 +113,10 @@ where
         let coefficient = Self::constraints(
             separation_challenge,
             WitnessValues {
-                left: evaluations.a_eval,
-                right: evaluations.b_eval,
-                output: evaluations.c_eval,
-                fourth: evaluations.d_eval,
+                a_eval: evaluations.wire_evals.a_eval,
+                b_eval: evaluations.wire_evals.b_eval,
+                c_eval: evaluations.wire_evals.c_eval,
+                d_eval: evaluations.wire_evals.d_eval,
             },
             // TODO
             custom_vals,

--- a/plonk-core/src/proof_system/widget/mod.rs
+++ b/plonk-core/src/proof_system/widget/mod.rs
@@ -20,12 +20,18 @@ use ark_ff::{FftField, PrimeField};
 use ark_poly::{univariate::DensePolynomial, Evaluations};
 use ark_serialize::*;
 
-/// Gate Values
+pub trait CustomValues<F>
+where
+    F: PrimeField,
+{
+}
+
+/// Witness Values
 ///
 /// This data structures holds the wire values for a given gate.
 #[derive(derivative::Derivative)]
 #[derivative(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
-pub struct GateValues<F>
+pub struct WitnessValues<F>
 where
     F: PrimeField,
 {
@@ -40,30 +46,6 @@ where
 
     /// Fourth Value
     pub fourth: F,
-
-    /// Next Left Value
-    ///
-    /// Only used in gates which use internal copy constraints.
-    pub left_next: F,
-
-    /// Next Right Value
-    ///
-    /// Only used in gates which use internal copy constraints.
-    pub right_next: F,
-
-    /// Next Fourth Value
-    ///
-    /// Only used in gates which use internal copy constraints.
-    pub fourth_next: F,
-
-    /// Left Wire Selector Weight
-    pub left_selector: F,
-
-    /// Right Wire Selector Weight
-    pub right_selector: F,
-
-    /// Constant Wire Selector Weight
-    pub constant_selector: F,
 }
 
 /// Gate Constraint
@@ -71,13 +53,19 @@ pub trait GateConstraint<F>
 where
     F: PrimeField,
 {
+    type CustomVals;
+
     /// Returns the coefficient of the quotient polynomial for this gate given
     /// an instantiation of the gate at `values` and a
     /// `separation_challenge` if this gate requires it for soundness.
     ///
     /// This method is an encoding of the polynomial constraint(s) that this
     /// gate represents whenever it is added to a circuit.
-    fn constraints(separation_challenge: F, values: GateValues<F>) -> F;
+    fn constraints(
+        separation_challenge: F,
+        wit_vals: WitnessValues<F>,
+        custom_vals: Self::CustomVals,
+    ) -> F;
 
     /// Computes the quotient polynomial term for the given gate type for the
     /// given value of `selector` instantiated with `separation_challenge` and
@@ -85,9 +73,11 @@ where
     fn quotient_term(
         selector: F,
         separation_challenge: F,
-        values: GateValues<F>,
+        wit_vals: WitnessValues<F>,
+        custom_vals: Self::CustomVals,
     ) -> F {
-        selector * Self::constraints(separation_challenge, values)
+        selector
+            * Self::constraints(separation_challenge, wit_vals, custom_vals)
     }
 
     /// Computes the linearisation polynomial term for the given gate type
@@ -96,9 +86,11 @@ where
     fn linearisation_term(
         selector_polynomial: &DensePolynomial<F>,
         separation_challenge: F,
-        values: GateValues<F>,
+        wit_vals: WitnessValues<F>,
+        custom_vals: Self::CustomVals,
     ) -> DensePolynomial<F> {
-        selector_polynomial * Self::constraints(separation_challenge, values)
+        selector_polynomial
+            * Self::constraints(separation_challenge, wit_vals, custom_vals)
     }
 
     /// Extends `scalars` and `points` to build the linearisation commitment
@@ -115,18 +107,21 @@ where
     {
         let coefficient = Self::constraints(
             separation_challenge,
-            GateValues {
+            WitnessValues {
                 left: evaluations.a_eval,
                 right: evaluations.b_eval,
                 output: evaluations.c_eval,
                 fourth: evaluations.d_eval,
-                left_next: evaluations.a_next_eval,
-                right_next: evaluations.b_next_eval,
-                fourth_next: evaluations.d_next_eval,
-                left_selector: evaluations.q_l_eval,
-                right_selector: evaluations.q_r_eval,
-                constant_selector: evaluations.q_c_eval,
             },
+            // TODO
+            custom_vals,
+            /* left_next: evaluations.a_next_eval,
+             * right_next: evaluations.b_next_eval,
+             * fourth_next: evaluations.d_next_eval,
+             * left_selector: evaluations.q_l_eval,
+             * right_selector: evaluations.q_r_eval,
+             * constant_selector: evaluations.q_c_eval,
+             * }, */
         );
         scalars.push(coefficient);
         points.push(selector_commitment.clone());

--- a/plonk-core/src/proof_system/widget/range.rs
+++ b/plonk-core/src/proof_system/widget/range.rs
@@ -6,7 +6,12 @@
 
 //! Range Gate
 
-use crate::proof_system::{GateConstraint, WitnessValues};
+use crate::{
+    get_label,
+    proof_system::{
+        linearisation_poly::CustomEvaluations, GateConstraint, WitnessValues,
+    },
+};
 use ark_ff::PrimeField;
 use core::marker::PhantomData;
 
@@ -16,11 +21,18 @@ pub struct RangeVals<F>
 where
     F: PrimeField,
 {
-    pub fourth_next: F,
+    pub d_next_eval: F,
 }
 
-impl<F> CustomValues<F> for RangeVals<F> where F: PrimeField {}
-
+impl<F> CustomValues<F> for RangeVals<F>
+where
+    F: PrimeField,
+{
+    fn from_evaluations(custom_evals: CustomEvaluations<F>) -> Self {
+        let d_next_eval = custom_evals.get(get_label!(d_next_eval));
+        RangeVals { d_next_eval }
+    }
+}
 /// Range Gate
 #[derive(derivative::Derivative)]
 #[derivative(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
@@ -43,11 +55,11 @@ where
         let kappa = separation_challenge.square();
         let kappa_sq = kappa.square();
         let kappa_cu = kappa_sq * kappa;
-        let b_1 = delta(wit_vals.output - four * wit_vals.fourth);
-        let b_2 = delta(wit_vals.right - four * wit_vals.output) * kappa;
-        let b_3 = delta(wit_vals.left - four * wit_vals.right) * kappa_sq;
+        let b_1 = delta(wit_vals.c_eval - four * wit_vals.d_eval);
+        let b_2 = delta(wit_vals.r_eval - four * wit_vals.c_eval) * kappa;
+        let b_3 = delta(wit_vals.a_eval - four * wit_vals.r_eval) * kappa_sq;
         let b_4 =
-            delta(custom_vals.fourth_next - four * wit_vals.left) * kappa_cu;
+            delta(custom_vals.d_next_eval - four * wit_vals.a_eval) * kappa_cu;
         (b_1 + b_2 + b_3 + b_4) * separation_challenge
     }
 }

--- a/plonk-core/src/proof_system/widget/range.rs
+++ b/plonk-core/src/proof_system/widget/range.rs
@@ -7,12 +7,11 @@
 //! Range Gate
 
 use crate::proof_system::{
-    linearisation_poly::CustomEvaluations, GateConstraint, WitnessValues,
+    linearisation_poly::CustomEvaluations, CustomValues, GateConstraint,
+    WitnessValues,
 };
 use ark_ff::PrimeField;
 use core::marker::PhantomData;
-
-use super::CustomValues;
 
 /// Values needed for the computation of the range gate constraint.
 pub struct RangeVals<F>

--- a/plonk-core/src/proof_system/widget/range.rs
+++ b/plonk-core/src/proof_system/widget/range.rs
@@ -14,10 +14,12 @@ use core::marker::PhantomData;
 
 use super::CustomValues;
 
+/// Values needed for the computation of the range gate constraint.
 pub struct RangeVals<F>
 where
     F: PrimeField,
 {
+    /// Fourth wire value in the next position
     pub d_next_val: F,
 }
 

--- a/plonk-core/src/proof_system/widget/range.rs
+++ b/plonk-core/src/proof_system/widget/range.rs
@@ -25,7 +25,7 @@ impl<F> CustomValues<F> for RangeVals<F>
 where
     F: PrimeField,
 {
-    fn from_evaluations(custom_vals: CustomEvaluations<F>) -> Self {
+    fn from_evaluations(custom_vals: &CustomEvaluations<F>) -> Self {
         let d_next_val = custom_vals.get("d_next_eval");
         RangeVals { d_next_val }
     }

--- a/plonk-core/src/proof_system/widget/range.rs
+++ b/plonk-core/src/proof_system/widget/range.rs
@@ -6,11 +6,8 @@
 
 //! Range Gate
 
-use crate::{
-    get_label,
-    proof_system::{
-        linearisation_poly::CustomEvaluations, GateConstraint, WitnessValues,
-    },
+use crate::proof_system::{
+    linearisation_poly::CustomEvaluations, GateConstraint, WitnessValues,
 };
 use ark_ff::PrimeField;
 use core::marker::PhantomData;
@@ -21,16 +18,16 @@ pub struct RangeVals<F>
 where
     F: PrimeField,
 {
-    pub d_next_eval: F,
+    pub d_next_val: F,
 }
 
 impl<F> CustomValues<F> for RangeVals<F>
 where
     F: PrimeField,
 {
-    fn from_evaluations(custom_evals: CustomEvaluations<F>) -> Self {
-        let d_next_eval = custom_evals.get(get_label!(d_next_eval));
-        RangeVals { d_next_eval }
+    fn from_evaluations(custom_vals: CustomEvaluations<F>) -> Self {
+        let d_next_val = custom_vals.get("d_next_eval");
+        RangeVals { d_next_val }
     }
 }
 /// Range Gate
@@ -55,11 +52,11 @@ where
         let kappa = separation_challenge.square();
         let kappa_sq = kappa.square();
         let kappa_cu = kappa_sq * kappa;
-        let b_1 = delta(wit_vals.c_eval - four * wit_vals.d_eval);
-        let b_2 = delta(wit_vals.r_eval - four * wit_vals.c_eval) * kappa;
-        let b_3 = delta(wit_vals.a_eval - four * wit_vals.r_eval) * kappa_sq;
+        let b_1 = delta(wit_vals.c_val - four * wit_vals.d_val);
+        let b_2 = delta(wit_vals.b_val - four * wit_vals.c_val) * kappa;
+        let b_3 = delta(wit_vals.a_val - four * wit_vals.b_val) * kappa_sq;
         let b_4 =
-            delta(custom_vals.d_next_eval - four * wit_vals.a_eval) * kappa_cu;
+            delta(custom_vals.d_next_val - four * wit_vals.a_val) * kappa_cu;
         (b_1 + b_2 + b_3 + b_4) * separation_challenge
     }
 }

--- a/plonk-core/src/proof_system/widget/range.rs
+++ b/plonk-core/src/proof_system/widget/range.rs
@@ -6,9 +6,20 @@
 
 //! Range Gate
 
-use crate::proof_system::{GateConstraint, GateValues};
+use crate::proof_system::{GateConstraint, WitnessValues};
 use ark_ff::PrimeField;
 use core::marker::PhantomData;
+
+use super::CustomValues;
+
+pub struct RangeVals<F>
+where
+    F: PrimeField,
+{
+    pub fourth_next: F,
+}
+
+impl<F> CustomValues<F> for RangeVals<F> where F: PrimeField {}
 
 /// Range Gate
 #[derive(derivative::Derivative)]
@@ -21,16 +32,22 @@ impl<F> GateConstraint<F> for Range<F>
 where
     F: PrimeField,
 {
+    type CustomVals = RangeVals<F>;
     #[inline]
-    fn constraints(separation_challenge: F, values: GateValues<F>) -> F {
+    fn constraints(
+        separation_challenge: F,
+        wit_vals: WitnessValues<F>,
+        custom_vals: Self::CustomVals,
+    ) -> F {
         let four = F::from(4u64);
         let kappa = separation_challenge.square();
         let kappa_sq = kappa.square();
         let kappa_cu = kappa_sq * kappa;
-        let b_1 = delta(values.output - four * values.fourth);
-        let b_2 = delta(values.right - four * values.output) * kappa;
-        let b_3 = delta(values.left - four * values.right) * kappa_sq;
-        let b_4 = delta(values.fourth_next - four * values.left) * kappa_cu;
+        let b_1 = delta(wit_vals.output - four * wit_vals.fourth);
+        let b_2 = delta(wit_vals.right - four * wit_vals.output) * kappa;
+        let b_3 = delta(wit_vals.left - four * wit_vals.right) * kappa_sq;
+        let b_4 =
+            delta(custom_vals.fourth_next - four * wit_vals.left) * kappa_cu;
         (b_1 + b_2 + b_3 + b_4) * separation_challenge
     }
 }

--- a/plonk-core/src/util.rs
+++ b/plonk-core/src/util.rs
@@ -167,3 +167,11 @@ macro_rules! label_commitment {
         )
     };
 }
+
+/// Macro to quickly label evaluations
+#[macro_export]
+macro_rules! label_eval {
+    ($eval:expr) => {
+        (stringify!($comm).to_owned(), $eval)
+    };
+}

--- a/plonk-core/src/util.rs
+++ b/plonk-core/src/util.rs
@@ -172,7 +172,7 @@ macro_rules! label_commitment {
 #[macro_export]
 macro_rules! label_eval {
     ($eval:expr) => {
-        (stringify!($comm).to_owned(), $eval)
+        (stringify!($eval).to_owned(), $eval)
     };
 }
 

--- a/plonk-core/src/util.rs
+++ b/plonk-core/src/util.rs
@@ -175,3 +175,11 @@ macro_rules! label_eval {
         (stringify!($comm).to_owned(), $eval)
     };
 }
+
+/// Macro to get appropirate label
+#[macro_export]
+macro_rules! get_label {
+    ($eval:expr) => {
+        stringify!($comm).to_owned()
+    };
+}


### PR DESCRIPTION
Refactor custom gates in order to abstract their contributions to proof, verifier and prover keys as well as the quotient and linearisation polynomial.

The objective is to detect unused custom gates at circuit compile time and eliminate all their contributions. This in turn:

- Reduces computation complexity of quotient and linearisation poly
- Reduces size of keys and proofs