### PR TITLE
Add challenges correctly to the transcript

### DIFF
--- a/plonk-core/src/proof_system/proof.rs
+++ b/plonk-core/src/proof_system/proof.rs
@@ -136,6 +136,7 @@ where
         let beta = transcript.challenge_scalar(b"beta");
         transcript.append(b"beta", &beta);
         let gamma = transcript.challenge_scalar(b"gamma");
+        transcript.append(b"gamma", &gamma);
 
         assert!(beta != gamma, "challenges must be different");
 

--- a/plonk-core/src/proof_system/prover.rs
+++ b/plonk-core/src/proof_system/prover.rs
@@ -294,7 +294,7 @@ where
         let beta = transcript.challenge_scalar(b"beta");
         transcript.append(b"beta", &beta);
         let gamma = transcript.challenge_scalar(b"gamma");
-
+        transcript.append(b"gamma", &gamma);
         assert!(beta != gamma, "challenges must be different");
 
         let mut z_poly = DensePolynomial::from_coefficients_slice(


### PR DESCRIPTION
Currently, most transcript.challenge_scalar are only generated, but not added to the transcript. We must do this correctly. Can we test that the implementation matches the specification.