### PR TITLE
Faster tests

### DIFF
--- a/plonk-core/src/circuit.rs
+++ b/plonk-core/src/circuit.rs
@@ -202,7 +202,7 @@ where
 /// // Generate CRS
 /// type PC = SonicKZG10::<Bls12_381,DensePolynomial<BlsScalar>>;
 /// let pp = PC::setup(
-///     1 << 12, None, &mut OsRng
+///     1 << 10, None, &mut OsRng
 ///  )?;
 ///
 /// let mut circuit = TestCircuit::<BlsScalar, JubJubParameters>::default();
@@ -492,7 +492,7 @@ mod test {
         VerifierData<F, PC>: PartialEq,
     {
         // Generate CRS
-        let pp = PC::setup(1 << 19, None, &mut OsRng)
+        let pp = PC::setup(1 << 10, None, &mut OsRng)
             .map_err(to_pc_error::<F, PC>)?;
 
         let mut circuit = TestCircuit::<F, P>::default();

--- a/plonk-core/src/test.rs
+++ b/plonk-core/src/test.rs
@@ -87,7 +87,7 @@ macro_rules! batch_test {
             $(
                 #[test]
                 #[allow(non_snake_case)]
-                fn [< $test_set _on_ $engine>]() {
+                fn [< $test_set _on_ $engine _kzg>]() {
                     $test_set::<<$engine as ark_ec::PairingEngine>::Fr, $params, crate::commitment::KZG10<$engine>>()
                 }
                 #[test]
@@ -100,7 +100,7 @@ macro_rules! batch_test {
                 #[test]
                 #[should_panic]
                 #[allow(non_snake_case)]
-                fn [< $test_panic_set _on_ $engine>]() {
+                fn [< $test_panic_set _on_ $engine _kzg>]() {
                     $test_panic_set::<<$engine as ark_ec::PairingEngine>::Fr, $params, crate::commitment::KZG10<$engine>>()
                 }
                 #[test]


### PR DESCRIPTION
Closes  #119 .

Further improvements could be made by generating the SRS once and using it for all tests that need it.