### PR TITLE
Refactor Public Inputs and add them to the transcript

### DIFF
--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -137,10 +137,10 @@ where
     let mut verifying_benchmarks = c.benchmark_group("verify");
     for degree in MINIMUM_DEGREE..MAXIMUM_DEGREE {
         let mut circuit = BenchCircuit::<F, P>::new(degree);
-        let (pk_p, verifier_data) =
+        let (pk_p, vk) =
             circuit.compile(&pp).expect("Unable to compile circuit.");
-        let proof = circuit.gen_proof::<HC>(&pp, pk_p.clone(), &label).unwrap();
-        let VerifierData { key, pi_pos } = verifier_data;
+        let (proof, pi) =
+            circuit.gen_proof::<HC>(&pp, pk_p.clone(), &label).unwrap();
         verifying_benchmarks.bench_with_input(
             BenchmarkId::from_parameter(degree),
             &degree,
@@ -148,10 +148,9 @@ where
                 b.iter(|| {
                     plonk::circuit::verify_proof::<F, P, HC>(
                         &pp,
-                        key.clone(),
+                        vk.clone(),
                         &proof,
-                        &[],
-                        &pi_pos,
+                        &pi,
                         &label,
                     )
                     .expect("Unable to verify benchmark circuit.");

--- a/plonk-core/src/circuit.rs
+++ b/plonk-core/src/circuit.rs
@@ -10,7 +10,9 @@ use crate::{
     commitment::HomomorphicCommitment,
     error::{to_pc_error, Error},
     prelude::StandardComposer,
-    proof_system::{pi::PI, Proof, Prover, ProverKey, Verifier, VerifierKey},
+    proof_system::{
+        pi::PublicInputs, Proof, Prover, ProverKey, Verifier, VerifierKey,
+    },
 };
 use ark_ec::models::TEModelParameters;
 use ark_ff::PrimeField;
@@ -35,7 +37,7 @@ where
     /// Verifier Key
     pub key: VerifierKey<F, PC>,
     /// Public Input
-    pub pi: PI<F>,
+    pub pi: PublicInputs<F>,
 }
 
 impl<F, PC> VerifierData<F, PC>
@@ -45,7 +47,7 @@ where
 {
     /// Creates a new `VerifierData` from a [`VerifierKey`] and the public
     /// input positions of the circuit that it represents.
-    pub fn new(key: VerifierKey<F, PC>, pi: PI<F>) -> Self {
+    pub fn new(key: VerifierKey<F, PC>, pi: PublicInputs<F>) -> Self {
         Self { key, pi }
     }
 
@@ -55,7 +57,7 @@ where
     }
 
     /// Returns a reference to the contained Public Input .
-    pub fn pi(&self) -> &PI<F> {
+    pub fn pi(&self) -> &PublicInputs<F> {
         &self.pi
     }
 }
@@ -265,7 +267,7 @@ where
         u_params: &PC::UniversalParams,
         prover_key: ProverKey<F>,
         transcript_init: &'static [u8],
-    ) -> Result<(Proof<F, PC>, PI<F>), Error>
+    ) -> Result<(Proof<F, PC>, PublicInputs<F>), Error>
     where
         F: PrimeField,
         P: TEModelParameters<BaseField = F>,
@@ -296,7 +298,7 @@ pub fn verify_proof<F, P, PC>(
     u_params: &PC::UniversalParams,
     plonk_verifier_key: VerifierKey<F, PC>,
     proof: &Proof<F, PC>,
-    public_inputs: &PI<F>,
+    public_inputs: &PublicInputs<F>,
     transcript_init: &'static [u8],
 ) -> Result<(), Error>
 where

--- a/plonk-core/src/circuit.rs
+++ b/plonk-core/src/circuit.rs
@@ -10,56 +10,11 @@ use crate::{
     commitment::HomomorphicCommitment,
     error::{to_pc_error, Error},
     prelude::StandardComposer,
-    proof_system::{Proof, Prover, ProverKey, Verifier, VerifierKey},
+    proof_system::{pi::PI, Proof, Prover, ProverKey, Verifier, VerifierKey},
 };
 use ark_ec::models::TEModelParameters;
-use ark_ff::{Field, PrimeField, ToConstraintField};
+use ark_ff::PrimeField;
 use ark_serialize::*;
-
-/// Public Input Builder
-#[derive(derivative::Derivative)]
-#[derivative(Default(bound = ""))]
-pub struct PublicInputBuilder<F>
-where
-    F: PrimeField,
-{
-    input: Vec<F>,
-}
-
-impl<F> PublicInputBuilder<F>
-where
-    F: PrimeField,
-{
-    /// Creates a new PublicInputBuilder
-    pub fn new() -> Self {
-        Self { input: vec![] }
-    }
-    /// Pushes a new input `item` into `self`, returning `None` if `item` could
-    /// not be converted into constraint field elements.
-    pub fn add_input<T>(self, item: &T) -> Option<Self>
-    where
-        T: ToConstraintField<F>,
-    {
-        self.extend([item])
-    }
-    /// Extends the input buffer by appending all the elements of `iter`
-    /// converted into constraint field elements, returning `None` if any of
-    /// the conversions failed.
-    pub fn extend<'t, T, I>(mut self, iter: I) -> Option<Self>
-    where
-        T: 't + ToConstraintField<F>,
-        I: IntoIterator<Item = &'t T>,
-    {
-        for item in iter {
-            self.input.append(&mut item.to_field_elements()?);
-        }
-        Some(self)
-    }
-    /// Returns the vector of input elements.
-    pub fn finish(self) -> Vec<F> {
-        self.input
-    }
-}
 
 /// Collection of structs/objects that the Verifier will use in order to
 /// de/serialize data needed for Circuit proof verification.
@@ -79,9 +34,8 @@ where
 {
     /// Verifier Key
     pub key: VerifierKey<F, PC>,
-
-    /// Public Input Positions
-    pub pi_pos: Vec<usize>,
+    /// Public Input
+    pub pi: PI<F>,
 }
 
 impl<F, PC> VerifierData<F, PC>
@@ -91,8 +45,8 @@ where
 {
     /// Creates a new `VerifierData` from a [`VerifierKey`] and the public
     /// input positions of the circuit that it represents.
-    pub fn new(key: VerifierKey<F, PC>, pi_pos: Vec<usize>) -> Self {
-        Self { key, pi_pos }
+    pub fn new(key: VerifierKey<F, PC>, pi: PI<F>) -> Self {
+        Self { key, pi }
     }
 
     /// Returns a reference to the contained [`VerifierKey`].
@@ -100,9 +54,9 @@ where
         &self.key
     }
 
-    /// Returns a reference to the contained Public Input positions.
-    pub fn pi_pos(&self) -> &[usize] {
-        &self.pi_pos
+    /// Returns a reference to the contained Public Input .
+    pub fn pi(&self) -> &PI<F> {
+        &self.pi
     }
 }
 
@@ -122,7 +76,7 @@ where
 ///     EdwardsProjective as JubJubProjective, Fr as JubJubScalar,
 /// };
 /// use ark_ff::{FftField, PrimeField, BigInteger, ToConstraintField};
-/// use plonk_core::circuit::{Circuit, verify_proof, PublicInputBuilder};
+/// use plonk_core::circuit::{Circuit, verify_proof};
 /// use plonk_core::constraint_system::StandardComposer;
 /// use plonk_core::error::{to_pc_error,Error};
 /// use ark_poly::polynomial::univariate::DensePolynomial;
@@ -207,7 +161,7 @@ where
 ///
 /// let mut circuit = TestCircuit::<BlsScalar, JubJubParameters>::default();
 /// // Compile the circuit
-/// let (pk_p, verifier_data) = circuit.compile::<PC>(&pp)?;
+/// let (pk_p, vk) = circuit.compile::<PC>(&pp)?;
 ///
 /// let (x, y) = JubJubParameters::AFFINE_GENERATOR_COEFFS;
 /// let generator: GroupAffine<JubJubParameters> = GroupAffine::new(x, y);
@@ -217,7 +171,7 @@ where
 /// )
 /// .into_affine();
 /// // Prover POV
-/// let proof = {
+/// let (proof, pi) = {
 ///     let mut circuit: TestCircuit<BlsScalar, JubJubParameters> = TestCircuit {
 ///         a: BlsScalar::from(20u64),
 ///         b: BlsScalar::from(5u64),
@@ -229,6 +183,7 @@ where
 ///     circuit.gen_proof::<PC>(&pp, pk_p, b"Test")
 /// }?;
 ///
+/// let verifier_data = VerifierData::new(vk, pi);
 /// // Test serialisation for verifier_data
 /// let mut verifier_data_bytes = Vec::new();
 /// verifier_data.serialize(&mut verifier_data_bytes).unwrap();
@@ -239,23 +194,11 @@ where
 /// assert!(deserialized_verifier_data == verifier_data);
 ///
 /// // Verifier POV
-/// let public_inputs = PublicInputBuilder::new()
-///     .add_input(&BlsScalar::from(25u64))
-///     .unwrap()
-///     .add_input(&BlsScalar::from(100u64))
-///     .unwrap()
-///     .add_input(&point_f_pi)
-///     .unwrap()
-///     .finish();
-///
-/// let VerifierData { key, pi_pos } = verifier_data;
-/// // TODO: non-ideal hack for a first functional version.
 /// verify_proof::<BlsScalar, JubJubParameters, PC>(
 ///     &pp,
-///     key,
+///     verifier_data.key,
 ///     &proof,
-///     &public_inputs,
-///     &pi_pos,
+///     &verifier_data.pi,
 ///     b"Test",
 /// )
 /// }
@@ -275,12 +218,12 @@ where
     ) -> Result<(), Error>;
 
     /// Compiles the circuit by using a function that returns a `Result`
-    /// with the `ProverKey`, `VerifierKey` and the circuit size.
+    /// with the [`ProverKey`], [`VerifierKey`] and the circuit size.
     #[allow(clippy::type_complexity)] // NOTE: Clippy is too harsh here.
     fn compile<PC>(
         &mut self,
         u_params: &PC::UniversalParams,
-    ) -> Result<(ProverKey<F>, VerifierData<F, PC>), Error>
+    ) -> Result<(ProverKey<F>, VerifierKey<F, PC>), Error>
     where
         F: PrimeField,
         PC: HomomorphicCommitment<F>,
@@ -293,34 +236,35 @@ where
         //Generate & save `ProverKey` with some random values.
         let mut prover = Prover::<F, P, PC>::new(b"CircuitCompilation");
         self.gadget(prover.mut_cs())?;
-        let pi_pos = prover.mut_cs().pi_positions();
+        prover.cs.public_inputs.update_size(prover.circuit_bound());
         prover.preprocess(&ck)?;
 
         // Generate & save `VerifierKey` with some random values.
         let mut verifier = Verifier::new(b"CircuitCompilation");
         self.gadget(verifier.mut_cs())?;
+        verifier
+            .cs
+            .public_inputs
+            .update_size(verifier.circuit_bound());
         verifier.preprocess(&ck)?;
         Ok((
             prover
                 .prover_key
                 .expect("Unexpected error. Missing ProverKey in compilation"),
-            VerifierData::new(
-                verifier.verifier_key.expect(
-                    "Unexpected error. Missing VerifierKey in compilation",
-                ),
-                pi_pos,
-            ),
+            verifier
+                .verifier_key
+                .expect("Unexpected error. Missing VerifierKey in compilation"),
         ))
     }
 
-    /// Generates a proof using the provided `CircuitInputs` & `ProverKey`
-    /// instances.
+    /// Generates a proof using the provided [`ProverKey`] and
+    /// [`PC::UniversalParams`]. Returns a proof and the Public Inputs
     fn gen_proof<PC>(
         &mut self,
         u_params: &PC::UniversalParams,
         prover_key: ProverKey<F>,
         transcript_init: &'static [u8],
-    ) -> Result<Proof<F, PC>, Error>
+    ) -> Result<(Proof<F, PC>, PI<F>), Error>
     where
         F: PrimeField,
         P: TEModelParameters<BaseField = F>,
@@ -333,9 +277,12 @@ where
         let mut prover = Prover::new(transcript_init);
         // Fill witnesses for Prover
         self.gadget(prover.mut_cs())?;
+        prover.cs.public_inputs.update_size(circuit_size);
         // Add ProverKey to Prover
         prover.prover_key = Some(prover_key);
-        prover.prove(&ck)
+        let pi = prover.cs.get_pi().clone();
+
+        Ok((prover.prove(&ck)?, pi))
     }
 
     /// Returns the Circuit size padded to the next power of two.
@@ -348,8 +295,7 @@ pub fn verify_proof<F, P, PC>(
     u_params: &PC::UniversalParams,
     plonk_verifier_key: VerifierKey<F, PC>,
     proof: &Proof<F, PC>,
-    pub_inputs_values: &[F],
-    pub_inputs_positions: &[usize],
+    public_inputs: &PI<F>,
     transcript_init: &'static [u8],
 ) -> Result<(), Error>
 where
@@ -363,31 +309,7 @@ where
     let (_, vk) = PC::trim(u_params, padded_circuit_size, 0, None)
         .map_err(to_pc_error::<F, PC>)?;
 
-    verifier.verify(
-        proof,
-        &vk,
-        build_pi(pub_inputs_values, pub_inputs_positions, padded_circuit_size)
-            .as_slice(),
-    )
-}
-
-/// Build PI vector for Proof verifications.
-fn build_pi<'a, F>(
-    pub_input_values: impl IntoIterator<Item = &'a F>,
-    pub_input_pos: &[usize],
-    trim_size: usize,
-) -> Vec<F>
-where
-    F: Field,
-{
-    let mut pi = vec![F::zero(); trim_size];
-    pub_input_values
-        .into_iter()
-        .zip(pub_input_pos.iter().copied())
-        .for_each(|(value, pos)| {
-            pi[pos] = -*value;
-        });
-    pi
+    verifier.verify(proof, &vk, &public_inputs)
 }
 
 #[cfg(test)]
@@ -480,7 +402,10 @@ mod test {
         let mut circuit = TestCircuit::<F, P>::default();
 
         // Compile the circuit
-        let (pk_p, verifier_data) = circuit.compile::<PC>(&pp)?;
+        let (pk, vk) = circuit.compile::<PC>(&pp)?;
+
+        //Add PI to the verifier data
+        // verifier_data.pi.insert()
 
         let (x, y) = P::AFFINE_GENERATOR_COEFFS;
         let generator: GroupAffine<P> = GroupAffine::new(x, y);
@@ -491,7 +416,7 @@ mod test {
         .into_affine();
 
         // Prover POV
-        let proof = {
+        let (proof, pi) = {
             let mut circuit: TestCircuit<F, P> = TestCircuit {
                 a: F::from(20u64),
                 b: F::from(5u64),
@@ -501,8 +426,10 @@ mod test {
                 f: point_f_pi,
             };
 
-            circuit.gen_proof::<PC>(&pp, pk_p, b"Test")?
+            circuit.gen_proof::<PC>(&pp, pk, b"Test")?
         };
+
+        let verifier_data = VerifierData::new(vk, pi);
 
         // Test serialisation for verifier_data
         let mut verifier_data_bytes = Vec::new();
@@ -514,24 +441,13 @@ mod test {
         assert!(deserialized_verifier_data == verifier_data);
 
         // Verifier POV
-        let public_inputs = PublicInputBuilder::new()
-            .add_input(&F::from(25u64))
-            .unwrap()
-            .add_input(&F::from(100u64))
-            .unwrap()
-            .add_input(&point_f_pi)
-            .unwrap()
-            .finish();
-
-        let VerifierData { key, pi_pos } = verifier_data;
 
         // TODO: non-ideal hack for a first functional version.
         assert!(verify_proof::<F, P, PC>(
             &pp,
-            key,
+            verifier_data.key,
             &proof,
-            &public_inputs,
-            &pi_pos,
+            &verifier_data.pi,
             b"Test",
         )
         .is_ok());

--- a/plonk-core/src/circuit.rs
+++ b/plonk-core/src/circuit.rs
@@ -261,7 +261,7 @@ where
 
     /// Generates a proof using the provided [`ProverKey`] and
     /// [`ark_poly_commit::PCUniversalParams`]. Returns a
-    /// [`crate::proof_system::Proof`] and the [`PI`].
+    /// [`crate::proof_system::Proof`] and the [`PublicInputs`].
     fn gen_proof<PC>(
         &mut self,
         u_params: &PC::UniversalParams,

--- a/plonk-core/src/circuit.rs
+++ b/plonk-core/src/circuit.rs
@@ -258,7 +258,8 @@ where
     }
 
     /// Generates a proof using the provided [`ProverKey`] and
-    /// [`PC::UniversalParams`]. Returns a proof and the Public Inputs
+    /// [`ark_poly_commit::PCUniversalParams`]. Returns a
+    /// [`crate::proof_system::Proof`] and the [`PI`].
     fn gen_proof<PC>(
         &mut self,
         u_params: &PC::UniversalParams,
@@ -309,7 +310,7 @@ where
     let (_, vk) = PC::trim(u_params, padded_circuit_size, 0, None)
         .map_err(to_pc_error::<F, PC>)?;
 
-    verifier.verify(proof, &vk, &public_inputs)
+    verifier.verify(proof, &vk, public_inputs)
 }
 
 #[cfg(test)]

--- a/plonk-core/src/circuit.rs
+++ b/plonk-core/src/circuit.rs
@@ -405,9 +405,6 @@ mod test {
         // Compile the circuit
         let (pk, vk) = circuit.compile::<PC>(&pp)?;
 
-        //Add PI to the verifier data
-        // verifier_data.pi.insert()
-
         let (x, y) = P::AFFINE_GENERATOR_COEFFS;
         let generator: GroupAffine<P> = GroupAffine::new(x, y);
         let point_f_pi: GroupAffine<P> = AffineCurve::mul(

--- a/plonk-core/src/constraint_system/arithmetic.rs
+++ b/plonk-core/src/constraint_system/arithmetic.rs
@@ -136,11 +136,7 @@ where
         self.q_lookup.push(F::zero());
 
         if let Some(pi) = gate.pi {
-            let insert_res = self.public_inputs_sparse_store.insert(self.n, pi);
-            assert!(
-                insert_res.is_none(),
-                "Attempting to overwrite an already existing PI"
-            )
+            self.public_inputs.insert(self.n, pi);
         };
 
         let c = gate_witness.2.unwrap_or_else(|| {

--- a/plonk-core/src/constraint_system/composer.rs
+++ b/plonk-core/src/constraint_system/composer.rs
@@ -137,7 +137,7 @@ where
     /// Constructs a dense vector of the Public Inputs from the positions and
     /// the sparse vector that contains the values.
     pub fn construct_dense_pi_vec(&self) -> Vec<F> {
-        let mut pi = vec![F::zero(); self.n];
+        let mut pi = vec![F::zero(); self.n.next_power_of_two()];
         self.public_inputs_sparse_store
             .iter()
             .for_each(|(pos, value)| {

--- a/plonk-core/src/constraint_system/composer.rs
+++ b/plonk-core/src/constraint_system/composer.rs
@@ -125,7 +125,7 @@ where
     /// Constructs a dense vector of the Public Inputs from the positions and
     /// the sparse vector that contains the values.
     pub fn construct_dense_pi_vec(&self) -> Vec<F> {
-        let mut pi = vec![F::zero(); self.n];
+        let mut pi = vec![F::zero(); self.n.next_power_of_two()];
         self.public_inputs_sparse_store
             .iter()
             .for_each(|(pos, value)| {

--- a/plonk-core/src/constraint_system/composer.rs
+++ b/plonk-core/src/constraint_system/composer.rs
@@ -134,7 +134,8 @@ where
         self.total_size().next_power_of_two()
     }
 
-    /// Returns a reference to the [`PI`] stored in the [`StandardComposer`].
+    /// Returns a reference to the [`PublicInputs`] stored in the
+    /// [`StandardComposer`].
     pub fn get_pi(&self) -> &PublicInputs<F> {
         &self.public_inputs
     }

--- a/plonk-core/src/constraint_system/composer.rs
+++ b/plonk-core/src/constraint_system/composer.rs
@@ -15,9 +15,9 @@
 //! ECC op. gates, Range checks, Logical gates (Bitwise ops) etc.
 
 use crate::{constraint_system::Variable, permutation::Permutation};
-use alloc::collections::BTreeMap;
 
 use crate::lookup::LookupTable;
+use crate::proof_system::pi::PI;
 use ark_ec::{models::TEModelParameters, ModelParameters};
 use ark_ff::PrimeField;
 use core::cmp::max;
@@ -88,7 +88,7 @@ where
 
     /// Sparse representation of the Public Inputs linking the positions of the
     /// non-zero ones to it's actual values.
-    pub(crate) public_inputs_sparse_store: BTreeMap<usize, F>,
+    pub(crate) public_inputs: PI<F>,
 
     // Witness vectors
     /// Left wire witness vector.
@@ -124,34 +124,19 @@ where
     F: PrimeField,
     P: ModelParameters<BaseField = F>,
 {
-    /// Returns the length of the circuit that can accomodate the lookup table
+    /// Returns the length of the circuit that can accomodate the lookup table.
     fn total_size(&self) -> usize {
         max(self.n, self.lookup_table.size())
     }
 
-    /// Returns the smallest power of two needed for the curcuit
+    /// Returns the smallest power of two needed for the curcuit.
     pub fn circuit_bound(&self) -> usize {
         self.total_size().next_power_of_two()
     }
 
-    /// Constructs a dense vector of the Public Inputs from the positions and
-    /// the sparse vector that contains the values.
-    pub fn construct_dense_pi_vec(&self) -> Vec<F> {
-        let mut pi = vec![F::zero(); self.n.next_power_of_two()];
-        self.public_inputs_sparse_store
-            .iter()
-            .for_each(|(pos, value)| {
-                pi[*pos] = *value;
-            });
-        pi
-    }
-
-    /// Returns the positions that the Public Inputs occupy in this Composer
-    /// instance.
-    pub fn pi_positions(&self) -> Vec<usize> {
-        // TODO: Find a more performant solution which can return a ref to a Vec
-        // or Iterator.
-        self.public_inputs_sparse_store.keys().copied().collect()
+    /// Returns a reference to the [`PI`] stored in the [`StandardComposer`].
+    pub fn get_pi(&self) -> &PI<F> {
+        &self.public_inputs
     }
 }
 
@@ -210,7 +195,7 @@ where
             q_fixed_group_add: Vec::with_capacity(expected_size),
             q_variable_group_add: Vec::with_capacity(expected_size),
             q_lookup: Vec::with_capacity(expected_size),
-            public_inputs_sparse_store: BTreeMap::new(),
+            public_inputs: PI::new(expected_size.next_power_of_two()),
             w_l: Vec::with_capacity(expected_size),
             w_r: Vec::with_capacity(expected_size),
             w_o: Vec::with_capacity(expected_size),
@@ -294,10 +279,7 @@ where
         self.q_lookup.push(F::zero());
 
         if let Some(pi) = pi {
-            assert!(self
-                .public_inputs_sparse_store
-                .insert(self.n, pi)
-                .is_none());
+            self.public_inputs.insert(self.n, pi);
         }
 
         self.perm
@@ -683,7 +665,7 @@ where
             let f_3 = f - F::from(3u64);
             f * f_1 * f_2 * f_3
         };
-        let pi_vec = self.construct_dense_pi_vec();
+        let pi_vec = self.public_inputs.as_evals();
         let four = F::from(4u64);
         for i in 0..self.n {
             let qm = self.q_m[i];
@@ -965,7 +947,7 @@ mod test {
         // Preprocess circuit
         prover.preprocess(&ck).unwrap();
 
-        let public_inputs = prover.cs.construct_dense_pi_vec();
+        let public_inputs = prover.cs.get_pi().clone();
 
         let mut proofs = Vec::new();
 

--- a/plonk-core/src/constraint_system/composer.rs
+++ b/plonk-core/src/constraint_system/composer.rs
@@ -17,7 +17,7 @@
 use crate::{constraint_system::Variable, permutation::Permutation};
 
 use crate::lookup::LookupTable;
-use crate::proof_system::pi::PI;
+use crate::proof_system::pi::PublicInputs;
 use ark_ec::{models::TEModelParameters, ModelParameters};
 use ark_ff::PrimeField;
 use core::cmp::max;
@@ -88,7 +88,7 @@ where
 
     /// Sparse representation of the Public Inputs linking the positions of the
     /// non-zero ones to it's actual values.
-    pub(crate) public_inputs: PI<F>,
+    pub(crate) public_inputs: PublicInputs<F>,
 
     // Witness vectors
     /// Left wire witness vector.
@@ -135,7 +135,7 @@ where
     }
 
     /// Returns a reference to the [`PI`] stored in the [`StandardComposer`].
-    pub fn get_pi(&self) -> &PI<F> {
+    pub fn get_pi(&self) -> &PublicInputs<F> {
         &self.public_inputs
     }
 }
@@ -195,7 +195,7 @@ where
             q_fixed_group_add: Vec::with_capacity(expected_size),
             q_variable_group_add: Vec::with_capacity(expected_size),
             q_lookup: Vec::with_capacity(expected_size),
-            public_inputs: PI::new(expected_size.next_power_of_two()),
+            public_inputs: PublicInputs::new(expected_size.next_power_of_two()),
             w_l: Vec::with_capacity(expected_size),
             w_r: Vec::with_capacity(expected_size),
             w_o: Vec::with_capacity(expected_size),

--- a/plonk-core/src/constraint_system/helper.rs
+++ b/plonk-core/src/constraint_system/helper.rs
@@ -58,6 +58,7 @@ where
 
         // Add gadgets
         gadget(prover.mut_cs());
+        prover.cs.public_inputs.update_size(prover.circuit_bound());
 
         // Commit Key
         let (ck, _) =
@@ -69,7 +70,7 @@ where
 
         // Once the prove method is called, the public inputs are cleared
         // So pre-fetch these before calling Prove
-        let public_inputs = prover.cs.construct_dense_pi_vec();
+        let public_inputs = prover.cs.get_pi().clone();
 
         // Compute Proof
         (prover.prove(&ck)?, public_inputs)
@@ -78,12 +79,17 @@ where
     //
     // Create a Verifier object
     let mut verifier = Verifier::new(b"demo");
+    // panic!("{:?}", verifier.cs.public_inputs);
 
     // Additionally key the transcript
     verifier.key_transcript(b"key", b"additional seed information");
 
     // Add gadgets
     gadget(verifier.mut_cs());
+    verifier
+        .cs
+        .public_inputs
+        .update_size(verifier.circuit_bound());
 
     // Compute Commit and Verifier Key
     let (ck, vk) =

--- a/plonk-core/src/constraint_system/helper.rs
+++ b/plonk-core/src/constraint_system/helper.rs
@@ -79,7 +79,6 @@ where
     //
     // Create a Verifier object
     let mut verifier = Verifier::new(b"demo");
-    // panic!("{:?}", verifier.cs.public_inputs);
 
     // Additionally key the transcript
     verifier.key_transcript(b"key", b"additional seed information");

--- a/plonk-core/src/constraint_system/lookup.rs
+++ b/plonk-core/src/constraint_system/lookup.rs
@@ -52,10 +52,7 @@ where
         self.q_lookup.push(F::one());
 
         if let Some(pi) = pi {
-            assert!(self
-                .public_inputs_sparse_store
-                .insert(self.n, pi)
-                .is_none());
+            self.public_inputs.insert(self.n, pi);
         }
 
         self.perm.add_variables_to_map(a, b, c, d, self.n);

--- a/plonk-core/src/error.rs
+++ b/plonk-core/src/error.rs
@@ -30,6 +30,8 @@ pub enum Error {
     UninitializedPIGenerator,
     /// PublicInput serialization error
     InvalidPublicInputBytes,
+    /// PublicInput value conversion error
+    InvalidPublicInputValue,
     /// This error occurs when the Prover structure already contains a
     /// preprocessed circuit inside, but you call preprocess again.
     CircuitAlreadyPreprocessed,
@@ -127,6 +129,9 @@ impl std::fmt::Display for Error {
             }
             Self::InvalidPublicInputBytes => {
                 write!(f, "invalid public input bytes")
+            }
+            Self::InvalidPublicInputValue => {
+                write!(f, "public input value conversion error")
             }
             Self::MismatchedPolyLen => {
                 write!(f, "the length of the wires is not the same")

--- a/plonk-core/src/proof_system/mod.rs
+++ b/plonk-core/src/proof_system/mod.rs
@@ -12,6 +12,7 @@ mod preprocess;
 mod quotient_poly;
 mod widget;
 
+pub mod pi;
 pub mod proof;
 pub mod prover;
 pub mod verifier;

--- a/plonk-core/src/proof_system/pi.rs
+++ b/plonk-core/src/proof_system/pi.rs
@@ -24,9 +24,8 @@ use ark_serialize::{
 use crate::prelude::Error;
 
 ///  Public Inputs
-#[derive(
-    CanonicalDeserialize, CanonicalSerialize, Clone, PartialEq, Debug, Hash,
-)]
+#[derive(CanonicalDeserialize, CanonicalSerialize, derivative::Derivative)]
+#[derivative(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct PI<F>
 where
     F: FftField,

--- a/plonk-core/src/proof_system/pi.rs
+++ b/plonk-core/src/proof_system/pi.rs
@@ -7,9 +7,9 @@
 //! Public Inputs of the circuit. This values are available for the
 //! [`super::Prover`] and [`super::Verifier`].
 //!
-//! This module contains the implementation of the [`PI`] struct and all the
-//! basic manipulations such as inserting new values and getting the public
-//! inputs in evaluation or coefficient form.
+//! This module contains the implementation of the [`PublicInputs`] struct and
+//! all the basic manipulations such as inserting new values and getting the
+//! public inputs in evaluation or coefficient form.
 
 use alloc::collections::BTreeMap;
 use ark_ff::{FftField, ToConstraintField};
@@ -40,7 +40,7 @@ impl<F> PublicInputs<F>
 where
     F: FftField,
 {
-    /// Creates a new struct for [`PI`].
+    /// Creates a new struct for [`PublicInputs`].
     pub fn new(n: usize) -> Self {
         assert!(n.is_power_of_two());
         Self {
@@ -134,7 +134,7 @@ mod test {
     use ark_bls12_377::Fr as Bls12_377_scalar_field;
     use ark_bls12_381::Fr as Bls12_381_scalar_field;
 
-    // Checks PI representation is not affected by insertion order
+    // Checks PublicInputs representation is not affected by insertion order
     // or extra zeros.
     fn test_pi_unique_repr<F>()
     where
@@ -157,7 +157,7 @@ mod test {
         assert_eq!(pi_1, pi_2);
     }
 
-    // Checks PI does not allow to override already inserted values.
+    // Checks PublicInputs does not allow to override already inserted values.
     fn test_pi_dup_insertion<F>()
     where
         F: FftField,

--- a/plonk-core/src/proof_system/pi.rs
+++ b/plonk-core/src/proof_system/pi.rs
@@ -11,8 +11,6 @@
 //! basic manipulations such as inserting new values and getting the public
 //! inputs in evaluation or coefficient form.
 
-use core::ops::Deref;
-
 use alloc::collections::BTreeMap;
 use ark_ff::{PrimeField, ToConstraintField};
 use ark_poly::{
@@ -37,16 +35,6 @@ where
     n: usize,
     // non-zero values of the public input
     values: BTreeMap<usize, F>,
-}
-
-impl<F> Deref for PI<F>
-where
-    F: PrimeField,
-{
-    type Target = BTreeMap<usize, F>;
-    fn deref(&self) -> &Self::Target {
-        &self.values
-    }
 }
 
 impl<F> PI<F>

--- a/plonk-core/src/proof_system/pi.rs
+++ b/plonk-core/src/proof_system/pi.rs
@@ -26,7 +26,7 @@ use crate::prelude::Error;
 ///  Public Inputs
 #[derive(CanonicalDeserialize, CanonicalSerialize, derivative::Derivative)]
 #[derivative(Clone, Debug, Default, Eq, Hash, PartialEq)]
-pub struct PI<F>
+pub struct PublicInputs<F>
 where
     F: FftField,
 {
@@ -36,7 +36,7 @@ where
     values: BTreeMap<usize, F>,
 }
 
-impl<F> PI<F>
+impl<F> PublicInputs<F>
 where
     F: FftField,
 {
@@ -117,11 +117,11 @@ where
     }
 }
 
-impl<F> From<&PI<F>> for DensePolynomial<F>
+impl<F> From<&PublicInputs<F>> for DensePolynomial<F>
 where
     F: FftField,
 {
-    fn from(pi: &PI<F>) -> Self {
+    fn from(pi: &PublicInputs<F>) -> Self {
         let domain = GeneralEvaluationDomain::<F>::new(pi.n).unwrap();
         let evals = pi.as_evals();
         DensePolynomial::from_coefficients_vec(domain.ifft(&evals))
@@ -141,13 +141,13 @@ mod test {
     where
         F: FftField,
     {
-        let mut pi_1 = PI::new(8);
+        let mut pi_1 = PublicInputs::new(8);
 
         pi_1.insert(2, F::from(2u64));
         pi_1.insert(5, F::from(5u64));
         pi_1.insert(6, F::from(6u64));
 
-        let mut pi_2 = PI::new(8);
+        let mut pi_2 = PublicInputs::new(8);
 
         pi_2.insert(6, F::from(6u64));
         pi_2.insert(5, F::from(5u64));
@@ -163,7 +163,7 @@ mod test {
     where
         F: FftField,
     {
-        let mut pi_1 = PI::new(8);
+        let mut pi_1 = PublicInputs::new(8);
 
         pi_1.insert(2, F::from(2u64));
         pi_1.insert(5, F::from(5u64));

--- a/plonk-core/src/proof_system/pi.rs
+++ b/plonk-core/src/proof_system/pi.rs
@@ -4,8 +4,8 @@
 //
 // Copyright (c) ZK-Garage. All rights reserved.
 
-//! Public Inputs of the circuit. This values are available for the [`Prover`]
-//! and [`Verifier`].
+//! Public Inputs of the circuit. This values are available for the
+//! [`super::Prover`] and [`super::Verifier`].
 //!
 //! This module contains the implementation of the [`PI`] struct and all the
 //! basic manipulations such as inserting new values and getting the public
@@ -68,7 +68,7 @@ where
 
     /// Inserts a new public input value at a given position.
     pub fn insert(&mut self, pos: usize, val: F) {
-        if let Some(_) = self.values.insert(pos, val) {
+        if self.values.insert(pos, val).is_some() {
             panic!("Insertion in public inputs conflicts with previous value at position {}", pos);
         }
     }
@@ -103,7 +103,7 @@ where
                 .to_field_elements()
                 .ok_or(Error::InvalidPublicInputValue)?;
 
-            for (pos2, elem) in item_repr.into_iter().enumerate() {
+            for (pos2, elem) in item_repr.iter().enumerate() {
                 self.values.insert(init_pos + pos1 + pos2, *elem);
                 result += 1;
             }
@@ -119,20 +119,13 @@ where
     }
 }
 
-impl<F> Into<DensePolynomial<F>> for &PI<F>
+impl<F> From<&PI<F>> for DensePolynomial<F>
 where
     F: PrimeField,
 {
-    fn into(self) -> DensePolynomial<F> {
-        let domain = GeneralEvaluationDomain::<F>::new(self.n).unwrap();
-        let evals = self.as_evals();
+    fn from(pi: &PI<F>) -> Self {
+        let domain = GeneralEvaluationDomain::<F>::new(pi.n).unwrap();
+        let evals = pi.as_evals();
         DensePolynomial::from_coefficients_vec(domain.ifft(&evals))
     }
 }
-
-// impl<F> for PI<F>
-// where
-//     F: Field,
-// {
-
-// }

--- a/plonk-core/src/proof_system/pi.rs
+++ b/plonk-core/src/proof_system/pi.rs
@@ -51,17 +51,6 @@ impl<F> PI<F>
 where
     F: PrimeField,
 {
-    //TODO Remove if unused
-    // #[inline]
-    // pub fn len(&self) -> usize {
-    //     self.values.len()
-    // }
-
-    // #[inline]
-    // pub fn is_empty(&self) -> bool {
-    //     self.values.is_empty()
-    // }
-
     /// Creates a new struct for [`PI`].
     pub fn new(n: usize) -> Self {
         assert!(n.is_power_of_two());

--- a/plonk-core/src/proof_system/pi.rs
+++ b/plonk-core/src/proof_system/pi.rs
@@ -128,3 +128,66 @@ where
         DensePolynomial::from_coefficients_vec(domain.ifft(&evals))
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::batch_field_test;
+    use ark_bls12_377::Fr as Bls12_377_scalar_field;
+    use ark_bls12_381::Fr as Bls12_381_scalar_field;
+
+    // Checks PI representation is not affected by insertion order
+    // or extra zeros.
+    fn test_pi_unique_repr<F>()
+    where
+        F: FftField,
+    {
+        let mut pi_1 = PI::new(8);
+
+        pi_1.insert(2, F::from(2u64));
+        pi_1.insert(5, F::from(5u64));
+        pi_1.insert(6, F::from(6u64));
+
+        let mut pi_2 = PI::new(8);
+
+        pi_2.insert(6, F::from(6u64));
+        pi_2.insert(5, F::from(5u64));
+        pi_2.insert(2, F::from(2u64));
+
+        pi_2.insert(0, F::zero());
+        pi_2.insert(1, F::zero());
+        assert_eq!(pi_1, pi_2);
+    }
+
+    // Checks PI does not allow to override already inserted values.
+    fn test_pi_dup_insertion<F>()
+    where
+        F: FftField,
+    {
+        let mut pi_1 = PI::new(8);
+
+        pi_1.insert(2, F::from(2u64));
+        pi_1.insert(5, F::from(5u64));
+        pi_1.insert(5, F::from(2u64));
+    }
+
+    // Bls12-381 tests
+    batch_field_test!(
+        [
+            test_pi_unique_repr
+        ],
+        [
+           test_pi_dup_insertion
+        ] => Bls12_381_scalar_field
+    );
+
+    // Bls12-377 tests
+    batch_field_test!(
+        [
+            test_pi_unique_repr
+        ],
+        [
+           test_pi_dup_insertion
+        ] => Bls12_377_scalar_field
+    );
+}

--- a/plonk-core/src/proof_system/pi.rs
+++ b/plonk-core/src/proof_system/pi.rs
@@ -95,18 +95,17 @@ where
         T: 't + ToConstraintField<F>,
         I: IntoIterator<Item = &'t T>,
     {
-        let mut result = 0;
-        for (pos1, item) in iter.into_iter().enumerate() {
-            let item_repr = &item
+        let mut count = 0;
+        for item in iter {
+            for elem in item
                 .to_field_elements()
-                .ok_or(Error::InvalidPublicInputValue)?;
-
-            for (pos2, elem) in item_repr.iter().enumerate() {
-                self.insert(init_pos + pos1 + pos2, *elem);
-                result += 1;
+                .ok_or(Error::InvalidPublicInputValue)?
+            {
+                self.insert(init_pos + count, elem);
+                count += 1;
             }
         }
-        Ok(result)
+        Ok(count)
     }
 
     /// Returns the public inputs as a vector of `n` evaluations.

--- a/plonk-core/src/proof_system/pi.rs
+++ b/plonk-core/src/proof_system/pi.rs
@@ -12,7 +12,7 @@
 //! inputs in evaluation or coefficient form.
 
 use alloc::collections::BTreeMap;
-use ark_ff::{PrimeField, ToConstraintField};
+use ark_ff::{FftField, ToConstraintField};
 use ark_poly::{
     polynomial::UVPolynomial, univariate::DensePolynomial, EvaluationDomain,
     GeneralEvaluationDomain,
@@ -29,7 +29,7 @@ use crate::prelude::Error;
 )]
 pub struct PI<F>
 where
-    F: PrimeField,
+    F: FftField,
 {
     // padded size of the circuit
     n: usize,
@@ -39,7 +39,7 @@ where
 
 impl<F> PI<F>
 where
-    F: PrimeField,
+    F: FftField,
 {
     /// Creates a new struct for [`PI`].
     pub fn new(n: usize) -> Self {
@@ -120,7 +120,7 @@ where
 
 impl<F> From<&PI<F>> for DensePolynomial<F>
 where
-    F: PrimeField,
+    F: FftField,
 {
     fn from(pi: &PI<F>) -> Self {
         let domain = GeneralEvaluationDomain::<F>::new(pi.n).unwrap();

--- a/plonk-core/src/proof_system/pi.rs
+++ b/plonk-core/src/proof_system/pi.rs
@@ -1,0 +1,85 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) ZK-Garage. All rights reserved.
+
+//! Public Inputs of the circuit. This values are available for the `Prover` and
+//! `Verifier`.
+//!
+//! This module contains the implementation of the `PI` struct and all the basic
+//! manipulations such as inserting new values and getting the public inputs in
+//! evaluation or coefficient form.
+
+use ark_ff::PrimeField;
+use ark_poly::{
+    polynomial::UVPolynomial, univariate::DensePolynomial, EvaluationDomain,
+    GeneralEvaluationDomain,
+};
+
+///  Public Inputs
+#[derive(Clone, PartialEq)]
+pub struct PI<F>
+where
+    F: PrimeField,
+{
+    // padded size of the circuit
+    n: usize,
+    // non-zero values of the public input
+    values: Vec<(usize, F)>,
+}
+
+impl<F> PI<F>
+where
+    F: PrimeField,
+{
+    //TODO Remove if unused
+    // #[inline]
+    // pub fn len(&self) -> usize {
+    //     self.values.len()
+    // }
+
+    // #[inline]
+    // pub fn is_empty(&self) -> bool {
+    //     self.values.is_empty()
+    // }
+
+    // #[inline]
+    // pub fn iter<'a>(&'a self) -> Iter<'a, F> {
+    //     Iter::new(&self.values[..])
+    // }
+
+    /// Creates a new struct for `PI`.
+    pub fn new(n: usize) -> Self {
+        assert!(n.is_power_of_two());
+        Self { n, values: vec![] }
+    }
+
+    /// Inserts a new public input value.
+    ///
+    /// Only the last value for any given position is taken into account.
+    /// Inserting a value effectively overrides any other value inserted at
+    /// the same position.
+    pub fn insert(&mut self, pos: usize, val: F) {
+        assert!(pos < self.n);
+        self.values.push((pos, val));
+    }
+
+    /// Returns the public inputs as a vector of `n` evaluations.
+    pub fn as_evals(&self) -> Vec<F> {
+        let mut pi = vec![F::zero(); self.n];
+        self.values.iter().for_each(|(pos, eval)| pi[*pos] = *eval);
+        pi
+    }
+}
+
+impl<F> Into<DensePolynomial<F>> for PI<F>
+where
+    F: PrimeField,
+{
+    fn into(self) -> DensePolynomial<F> {
+        let domain = GeneralEvaluationDomain::<F>::new(self.n).unwrap();
+        let evals = self.as_evals();
+        DensePolynomial::from_coefficients_vec(domain.fft(&evals))
+    }
+}

--- a/plonk-core/src/proof_system/proof.rs
+++ b/plonk-core/src/proof_system/proof.rs
@@ -33,7 +33,7 @@ use ark_serialize::{
 };
 use merlin::Transcript;
 
-use super::pi::PI;
+use super::pi::PublicInputs;
 
 /// A [`Proof`] is a composition of `Commitment`s to the Witness, Permutation,
 /// Quotient, Shifted and Opening polynomials as well as the
@@ -113,7 +113,7 @@ where
         plonk_verifier_key: &PlonkVerifierKey<F, PC>,
         transcript: &mut Transcript,
         verifier_key: &PC::VerifierKey,
-        pub_inputs: &PI<F>,
+        pub_inputs: &PublicInputs<F>,
     ) -> Result<(), Error>
     where
         P: TEModelParameters<BaseField = F>,

--- a/plonk-core/src/proof_system/proof.rs
+++ b/plonk-core/src/proof_system/proof.rs
@@ -35,15 +35,9 @@ use merlin::Transcript;
 
 use super::pi::PI;
 
-/// A Proof is a composition of `Commitment`s to the Witness, Permutation,
-/// Quotient, Shifted and Opening polynomials as well as the `ProofEvaluations`.
-///
-/// It's main goal is to allow the [`Verifier`](super::Verifier) to formally
-/// verify that the secret witnesses used to generate the [`Proof`] satisfy a
-/// circuit that both [`Prover`](super::Prover) and
-/// [`Verifier`](super::Verifier) have in common succintly and without any
-/// capabilities of adquiring any kind of knowledge about the witness used to
-/// construct the Proof.
+/// A [`Proof`] is a composition of `Commitment`s to the Witness, Permutation,
+/// Quotient, Shifted and Opening polynomials as well as the
+/// `ProofEvaluations`.
 #[derive(CanonicalDeserialize, CanonicalSerialize, derivative::Derivative)]
 #[derivative(
     Clone(bound = "PC::Commitment: Clone, PC::Proof: Clone"),

--- a/plonk-core/src/proof_system/proof.rs
+++ b/plonk-core/src/proof_system/proof.rs
@@ -129,6 +129,10 @@ where
                 adicity: <<F as FftField>::FftParams as ark_ff::FftParameters>::TWO_ADICITY,
             })?;
 
+        for val in pub_inputs {
+            transcript.append(b"pi", val)
+        }
+
         // Subgroup checks are done when the proof is deserialised.
 
         // In order for the Verifier and Prover to have the same view in the

--- a/plonk-core/src/proof_system/proof.rs
+++ b/plonk-core/src/proof_system/proof.rs
@@ -117,6 +117,10 @@ where
                 adicity: <<F as FftField>::FftParams as ark_ff::FftParameters>::TWO_ADICITY,
             })?;
 
+        for val in pub_inputs {
+            transcript.append(b"pi", val)
+        }
+
         // Subgroup checks are done when the proof is deserialised.
 
         // In order for the Verifier and Prover to have the same view in the

--- a/plonk-core/src/proof_system/proof.rs
+++ b/plonk-core/src/proof_system/proof.rs
@@ -4,11 +4,11 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-//! A Proof stores the commitments to all of the elements that
-//! are needed to univocally identify a prove of some statement.
+//! A Proof stores the commitments to all of the elements that are needed to
+//! univocally identify a prove of some statement.
 //!
-//! This module contains the implementation of the `StandardComposer`s
-//! `Proof` structure and it's methods.
+//! This module contains the implementation of the `StandardComposer`s [`Proof`]
+//! structure and it's methods.
 
 use crate::{
     commitment::HomomorphicCommitment,
@@ -36,12 +36,11 @@ use merlin::Transcript;
 use super::pi::PI;
 
 /// A Proof is a composition of `Commitment`s to the Witness, Permutation,
-/// Quotient, Shifted and Opening polynomials as well as the
-/// `ProofEvaluations`.
+/// Quotient, Shifted and Opening polynomials as well as the `ProofEvaluations`.
 ///
-/// It's main goal is to allow the `Verifier` to
-/// formally verify that the secret witnesses used to generate the [`Proof`]
-/// satisfy a circuit that both [`Prover`](super::Prover) and
+/// It's main goal is to allow the [`Verifier`](super::Verifier) to formally
+/// verify that the secret witnesses used to generate the [`Proof`] satisfy a
+/// circuit that both [`Prover`](super::Prover) and
 /// [`Verifier`](super::Verifier) have in common succintly and without any
 /// capabilities of adquiring any kind of knowledge about the witness used to
 /// construct the Proof.
@@ -132,13 +131,7 @@ where
             })?;
 
         // Append Public Inputs to the transcript
-        for (pos, val) in pub_inputs.iter() {
-            if !val.is_zero() {
-                let static_label =
-                    Box::leak(format!("pi{}", pos).into_boxed_str());
-                transcript.append(static_label.as_bytes(), val)
-            }
-        }
+        transcript.append(b"pi", pub_inputs);
 
         // Subgroup checks are done when the proof is deserialised.
 

--- a/plonk-core/src/proof_system/prover.rs
+++ b/plonk-core/src/proof_system/prover.rs
@@ -179,9 +179,12 @@ where
         let mut transcript = self.preprocessed_transcript.clone();
 
         // Append Public Inputs to the transcript
-        let pi_dense = self.cs.construct_dense_pi_vec();
-        for val in &pi_dense {
-            transcript.append(b"pi", val)
+        for (pos, val) in self.cs.get_pi().iter() {
+            if !val.is_zero() {
+                let static_label =
+                    Box::leak(format!("pi{}", pos).into_boxed_str());
+                transcript.append(static_label.as_bytes(), val)
+            }
         }
 
         // 1. Compute witness Polynomials
@@ -392,8 +395,7 @@ where
                 .map_err(to_pc_error::<F, PC>)?;
 
         // 3. Compute public inputs polynomial.
-        let pi_poly =
-            DensePolynomial::from_coefficients_vec(domain.ifft(&pi_dense));
+        let pi_poly = self.cs.get_pi().into();
 
         // 4. Compute quotient polynomial
         //

--- a/plonk-core/src/proof_system/prover.rs
+++ b/plonk-core/src/proof_system/prover.rs
@@ -178,6 +178,12 @@ where
         // Commitments
         let mut transcript = self.preprocessed_transcript.clone();
 
+        // Append Public Inputs to the transcript
+        let pi_dense = self.cs.construct_dense_pi_vec();
+        for val in &pi_dense {
+            transcript.append(b"pi", val)
+        }
+
         // 1. Compute witness Polynomials
         //
         // Convert Variables to scalars padding them to the
@@ -386,9 +392,8 @@ where
                 .map_err(to_pc_error::<F, PC>)?;
 
         // 3. Compute public inputs polynomial.
-        let pi_poly = DensePolynomial::from_coefficients_vec(
-            domain.ifft(&self.cs.construct_dense_pi_vec()),
-        );
+        let pi_poly =
+            DensePolynomial::from_coefficients_vec(domain.ifft(&pi_dense));
 
         // 4. Compute quotient polynomial
         //

--- a/plonk-core/src/proof_system/prover.rs
+++ b/plonk-core/src/proof_system/prover.rs
@@ -80,7 +80,7 @@ where
         &mut self.cs
     }
 
-    /// Returns the smallest power of two needed for the curcuit
+    /// Returns the smallest power of two needed for the curcuit.
     pub fn circuit_bound(&self) -> usize {
         self.cs.circuit_bound()
     }
@@ -135,7 +135,7 @@ where
         self.cs = StandardComposer::new();
     }
 
-    /// Clears all data in the `Prover` instance.
+    /// Clears all data in the [`Prover`] instance.
     ///
     /// This function is used when the user wants to use the same `Prover` to
     /// make a [`Proof`] regarding a different circuit.
@@ -179,13 +179,7 @@ where
         let mut transcript = self.preprocessed_transcript.clone();
 
         // Append Public Inputs to the transcript
-        for (pos, val) in self.cs.get_pi().iter() {
-            if !val.is_zero() {
-                let static_label =
-                    Box::leak(format!("pi{}", pos).into_boxed_str());
-                transcript.append(static_label.as_bytes(), val)
-            }
-        }
+        transcript.append(b"pi", self.cs.get_pi());
 
         // 1. Compute witness Polynomials
         //

--- a/plonk-core/src/proof_system/prover.rs
+++ b/plonk-core/src/proof_system/prover.rs
@@ -177,6 +177,12 @@ where
         // Commitments
         let mut transcript = self.preprocessed_transcript.clone();
 
+        // Append Public Inputs to the transcript
+        let pi_dense = self.cs.construct_dense_pi_vec();
+        for val in &pi_dense {
+            transcript.append(b"pi", val)
+        }
+
         // 1. Compute witness Polynomials
         //
         // Convert Variables to scalars padding them to the
@@ -248,9 +254,8 @@ where
         transcript.append(b"z", z_poly_commit[0].commitment());
 
         // 3. Compute public inputs polynomial.
-        let pi_poly = DensePolynomial::from_coefficients_vec(
-            domain.ifft(&self.cs.construct_dense_pi_vec()),
-        );
+        let pi_poly =
+            DensePolynomial::from_coefficients_vec(domain.ifft(&pi_dense));
 
         // 4. Compute quotient polynomial
         //

--- a/plonk-core/src/proof_system/verifier.rs
+++ b/plonk-core/src/proof_system/verifier.rs
@@ -18,7 +18,7 @@ use ark_ff::PrimeField;
 use core::marker::PhantomData;
 use merlin::Transcript;
 
-use super::pi::PI;
+use super::pi::PublicInputs;
 
 /// Abstraction structure designed verify [`Proof`]s.
 pub struct Verifier<F, P, PC>
@@ -107,7 +107,7 @@ where
         &self,
         proof: &Proof<F, PC>,
         pc_verifier_key: &PC::VerifierKey,
-        public_inputs: &PI<F>,
+        public_inputs: &PublicInputs<F>,
     ) -> Result<(), Error> {
         proof.verify::<P>(
             self.verifier_key.as_ref().unwrap(),

--- a/plonk-core/src/proof_system/verifier.rs
+++ b/plonk-core/src/proof_system/verifier.rs
@@ -18,6 +18,8 @@ use ark_ff::PrimeField;
 use core::marker::PhantomData;
 use merlin::Transcript;
 
+use super::pi::PI;
+
 /// Abstraction structure designed verify [`Proof`]s.
 pub struct Verifier<F, P, PC>
 where
@@ -105,7 +107,7 @@ where
         &self,
         proof: &Proof<F, PC>,
         pc_verifier_key: &PC::VerifierKey,
-        public_inputs: &[F],
+        public_inputs: &PI<F>,
     ) -> Result<(), Error> {
         proof.verify::<P>(
             self.verifier_key.as_ref().unwrap(),


### PR DESCRIPTION
In this PR we have added the Public Inputs to the transcript as the first step of the `prove` and `verify` algorithms. They have been added as the evaluations of the PI polynomial over the used domain (`n` field elements).

Close #133 