### PR TITLE
Allow extracting variables' values from composer

### DIFF
--- a/plonk-core/src/constraint_system/composer.rs
+++ b/plonk-core/src/constraint_system/composer.rs
@@ -815,9 +815,7 @@ where
     /// passed `var` was created by this composer before
     #[inline]
     pub fn value_of_var(&self, var: Variable) -> Option<F> {
-        self.variables
-            .get(&var)
-            .cloned()
+        self.variables.get(&var).cloned()
     }
 }
 

--- a/plonk-core/src/constraint_system/composer.rs
+++ b/plonk-core/src/constraint_system/composer.rs
@@ -811,11 +811,17 @@ where
         }
     }
 
-    /// Get value of a variable. Should be safe to `.unwrap()` as long as
-    /// passed `var` was created by this composer before
+    /// Get value of a variable that was previously created with
+    /// [`add_input`](StandardComposer::add_input),
+    /// [`conditional_select`](StandardComposer::conditional_select),
+    /// [`is_eq_with_output`](StandardComposer::is_eq_with_output)
+    /// or other similar method that returns a `Variable`.
     #[inline]
-    pub fn value_of_var(&self, var: Variable) -> Option<F> {
-        self.variables.get(&var).cloned()
+    pub fn value_of_var(&self, var: Variable) -> F {
+        self.variables
+            .get(&var)
+            .copied()
+            .expect("the variable does not exist")
     }
 }
 

--- a/plonk-core/src/constraint_system/composer.rs
+++ b/plonk-core/src/constraint_system/composer.rs
@@ -810,6 +810,15 @@ where
             assert_eq!(k, F::zero(), "Check failed at gate {}", i,);
         }
     }
+
+    /// Get value of a variable. Should be safe to `.unwrap()` as long as
+    /// passed `var` was created by this composer before
+    #[inline]
+    pub fn value_of_var(&self, var: Variable) -> Option<F> {
+        self.variables
+            .get(&var)
+            .cloned()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Is useful when inside `gadget()` method of circuit we mix calls to composer (including ones that produce new variables based on something, like `conditional_select` or `is_eq_with_output`) with calls to some external functions that take part in witness generation and need calculated values as inputs.