### PR TITLE
Addition circuit requires the A coefficient

### DIFF
--- a/plonk-core/src/proof_system/widget/ecc/curve_addition.rs
+++ b/plonk-core/src/proof_system/widget/ecc/curve_addition.rs
@@ -87,7 +87,7 @@ where
         let x3_consistency = (x3_lhs - x3_rhs) * kappa;
 
         // Check that `y_3` is correct
-        let y3_lhs = y1_y2 + x1_x2;
+        let y3_lhs = y1_y2 - P::COEFF_A * x1_x2;
         let y3_rhs = y_3 - y_3 * P::COEFF_D * x1_y2 * y1_x2;
         let y3_consistency = (y3_lhs - y3_rhs) * kappa.square();
 

--- a/plonk-core/src/proof_system/widget/ecc/fixed_base_scalar_mul.rs
+++ b/plonk-core/src/proof_system/widget/ecc/fixed_base_scalar_mul.rs
@@ -126,7 +126,7 @@ where
         // y accumulator consistency check
         let y_3 = acc_y_next;
         let lhs = y_3 - (y_3 * xy_alpha * acc_x * acc_y * P::COEFF_D);
-        let rhs = (x_alpha * acc_x) + (y_alpha * acc_y);
+        let rhs = y_alpha * acc_y - P::COEFF_A * x_alpha * acc_x;
         let y_acc_consistency = (lhs - rhs) * kappa_cu;
 
         let checks = bit_consistency


### PR DESCRIPTION
Custom addition gate is implemented for twisted Edwards curves with coefficient `a = -1`. We modify it so that it works for curves that do not have this property (Bandersnatch, or new BLS12 curves).  