### PR TITLE
Add intended PI positions 

### DIFF
--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -137,7 +137,7 @@ where
     let mut verifying_benchmarks = c.benchmark_group("verify");
     for degree in MINIMUM_DEGREE..MAXIMUM_DEGREE {
         let mut circuit = BenchCircuit::<F, P>::new(degree);
-        let (pk_p, vk) =
+        let (pk_p, (vk, _pi_pos)) =
             circuit.compile(&pp).expect("Unable to compile circuit.");
         let (proof, pi) =
             circuit.gen_proof::<HC>(&pp, pk_p.clone(), &label).unwrap();

--- a/examples/example_poly.rs
+++ b/examples/example_poly.rs
@@ -125,7 +125,7 @@ fn main() -> Result<(), Error> {
 
     let mut circuit = TestCircuit::<BlsScalar, JubJubParameters>::default();
     // Compile the circuit
-    let (pk_p, vk) = circuit.compile::<PC>(&pp)?;
+    let (pk_p, (vk, _pi_pos)) = circuit.compile::<PC>(&pp)?;
 
     // Prover POV
     let x = 1u64;

--- a/examples/simple_circuit.rs
+++ b/examples/simple_circuit.rs
@@ -98,7 +98,7 @@ fn main() -> Result<(), Error> {
 
     let mut circuit = TestCircuit::<BlsScalar, JubJubParameters>::default();
     // Compile the circuit
-    let (pk_p, vk) = circuit.compile::<PC>(&pp)?;
+    let (pk_p, (vk, _pi_pos)) = circuit.compile::<PC>(&pp)?;
 
     let (x, y) = JubJubParameters::AFFINE_GENERATOR_COEFFS;
     let generator: GroupAffine<JubJubParameters> = GroupAffine::new(x, y);

--- a/plonk-core/src/circuit.rs
+++ b/plonk-core/src/circuit.rs
@@ -46,7 +46,7 @@ where
     PC: HomomorphicCommitment<F>,
 {
     /// Creates a new `VerifierData` from a [`VerifierKey`] and the public
-    /// input positions of the circuit that it represents.
+    /// input of the circuit that it represents.
     pub fn new(key: VerifierKey<F, PC>, pi: PublicInputs<F>) -> Self {
         Self { key, pi }
     }

--- a/plonk-core/src/constraint_system/arithmetic.rs
+++ b/plonk-core/src/constraint_system/arithmetic.rs
@@ -136,7 +136,7 @@ where
         self.q_lookup.push(F::zero());
 
         if let Some(pi) = gate.pi {
-            self.public_inputs.insert(self.n, pi);
+            self.public_inputs.add_input(self.n, &pi).unwrap();
         };
 
         let c = gate_witness.2.unwrap_or_else(|| {

--- a/plonk-core/src/constraint_system/arithmetic.rs
+++ b/plonk-core/src/constraint_system/arithmetic.rs
@@ -136,7 +136,7 @@ where
         self.q_lookup.push(F::zero());
 
         if let Some(pi) = gate.pi {
-            self.public_inputs.add_input(self.n, &pi).unwrap();
+            self.add_pi(self.n, &pi).unwrap();
         };
 
         let c = gate_witness.2.unwrap_or_else(|| {

--- a/plonk-core/src/constraint_system/arithmetic.rs
+++ b/plonk-core/src/constraint_system/arithmetic.rs
@@ -136,7 +136,9 @@ where
         self.q_lookup.push(F::zero());
 
         if let Some(pi) = gate.pi {
-            self.add_pi(self.n, &pi).unwrap();
+            self.add_pi(self.n, &pi).unwrap_or_else(|_| {
+                panic!("Could not insert PI {:?} at {}", pi, self.n)
+            });
         };
 
         let c = gate_witness.2.unwrap_or_else(|| {

--- a/plonk-core/src/constraint_system/composer.rs
+++ b/plonk-core/src/constraint_system/composer.rs
@@ -215,7 +215,7 @@ where
             q_variable_group_add: Vec::with_capacity(expected_size),
             q_lookup: Vec::with_capacity(expected_size),
             public_inputs: PublicInputs::new(),
-            intended_pi_pos: Vec::with_capacity(expected_size),
+            intended_pi_pos: Vec::new(),
             w_l: Vec::with_capacity(expected_size),
             w_r: Vec::with_capacity(expected_size),
             w_o: Vec::with_capacity(expected_size),

--- a/plonk-core/src/constraint_system/composer.rs
+++ b/plonk-core/src/constraint_system/composer.rs
@@ -299,8 +299,10 @@ where
         self.q_lookup.push(F::zero());
 
         if let Some(pi) = pi {
-            self.add_pi(self.n, &pi).unwrap();
-        }
+            self.add_pi(self.n, &pi).unwrap_or_else(|_| {
+                panic!("Could not insert PI {:?} at {}", pi, self.n)
+            });
+        };
 
         self.perm
             .add_variables_to_map(a, b, c, self.zero_var, self.n);

--- a/plonk-core/src/constraint_system/composer.rs
+++ b/plonk-core/src/constraint_system/composer.rs
@@ -14,12 +14,14 @@
 //! It allows us not only to build Add and Mul constraints but also to build
 //! ECC op. gates, Range checks, Logical gates (Bitwise ops) etc.
 
-use crate::{constraint_system::Variable, permutation::Permutation};
+use crate::{
+    constraint_system::Variable, error::Error, permutation::Permutation,
+};
 
 use crate::lookup::LookupTable;
 use crate::proof_system::pi::PublicInputs;
 use ark_ec::{models::TEModelParameters, ModelParameters};
-use ark_ff::PrimeField;
+use ark_ff::{PrimeField, ToConstraintField};
 use core::cmp::max;
 use core::marker::PhantomData;
 use hashbrown::HashMap;
@@ -89,6 +91,7 @@ where
     /// Sparse representation of the Public Inputs linking the positions of the
     /// non-zero ones to it's actual values.
     pub(crate) public_inputs: PublicInputs<F>,
+    pub(crate) intended_pi_pos: Vec<usize>,
 
     // Witness vectors
     /// Left wire witness vector.
@@ -138,6 +141,21 @@ where
     /// [`StandardComposer`].
     pub fn get_pi(&self) -> &PublicInputs<F> {
         &self.public_inputs
+    }
+
+    /// Insert data in the PI starting at the given position and stores the
+    /// occupied positions as intended for public inputs.
+    pub(crate) fn add_pi<T>(
+        &mut self,
+        pos: usize,
+        item: &T,
+    ) -> Result<(), Error>
+    where
+        T: ToConstraintField<F>,
+    {
+        let n_positions = self.public_inputs.add_input(pos, item)?;
+        self.intended_pi_pos.extend(pos..(pos + n_positions));
+        Ok(())
     }
 }
 
@@ -197,6 +215,7 @@ where
             q_variable_group_add: Vec::with_capacity(expected_size),
             q_lookup: Vec::with_capacity(expected_size),
             public_inputs: PublicInputs::new(),
+            intended_pi_pos: Vec::with_capacity(expected_size),
             w_l: Vec::with_capacity(expected_size),
             w_r: Vec::with_capacity(expected_size),
             w_o: Vec::with_capacity(expected_size),
@@ -280,7 +299,7 @@ where
         self.q_lookup.push(F::zero());
 
         if let Some(pi) = pi {
-            self.public_inputs.add_input(self.n, &pi).unwrap();
+            self.add_pi(self.n, &pi).unwrap();
         }
 
         self.perm

--- a/plonk-core/src/constraint_system/composer.rs
+++ b/plonk-core/src/constraint_system/composer.rs
@@ -280,7 +280,7 @@ where
         self.q_lookup.push(F::zero());
 
         if let Some(pi) = pi {
-            self.public_inputs.insert(self.n, pi);
+            self.public_inputs.add_input(self.n, &pi).unwrap();
         }
 
         self.perm

--- a/plonk-core/src/constraint_system/lookup.rs
+++ b/plonk-core/src/constraint_system/lookup.rs
@@ -52,8 +52,10 @@ where
         self.q_lookup.push(F::one());
 
         if let Some(pi) = pi {
-            self.add_pi(self.n, &pi).unwrap();
-        }
+            self.add_pi(self.n, &pi).unwrap_or_else(|_| {
+                panic!("Could not insert PI {:?} at {}", pi, self.n)
+            });
+        };
 
         self.perm.add_variables_to_map(a, b, c, d, self.n);
 

--- a/plonk-core/src/constraint_system/lookup.rs
+++ b/plonk-core/src/constraint_system/lookup.rs
@@ -52,7 +52,7 @@ where
         self.q_lookup.push(F::one());
 
         if let Some(pi) = pi {
-            self.public_inputs.insert(self.n, pi);
+            self.public_inputs.add_input(self.n, &pi).unwrap();
         }
 
         self.perm.add_variables_to_map(a, b, c, d, self.n);

--- a/plonk-core/src/constraint_system/lookup.rs
+++ b/plonk-core/src/constraint_system/lookup.rs
@@ -52,7 +52,7 @@ where
         self.q_lookup.push(F::one());
 
         if let Some(pi) = pi {
-            self.public_inputs.add_input(self.n, &pi).unwrap();
+            self.add_pi(self.n, &pi).unwrap();
         }
 
         self.perm.add_variables_to_map(a, b, c, d, self.n);

--- a/plonk-core/src/proof_system/pi.rs
+++ b/plonk-core/src/proof_system/pi.rs
@@ -20,6 +20,7 @@ use ark_poly::{
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Read, SerializationError, Write,
 };
+use itertools::Itertools;
 
 use crate::prelude::Error;
 
@@ -51,7 +52,7 @@ where
     /// implicit value of empty positions.
     /// The function will panic if an insertion is atempted in an already
     /// occupied position.
-    pub fn insert(&mut self, pos: usize, val: F) {
+    fn insert(&mut self, pos: usize, val: F) {
         if self.values.contains_key(&pos) {
             panic!("Insertion in public inputs conflicts with previous value at position {}", pos);
         }
@@ -113,6 +114,27 @@ where
         let domain = GeneralEvaluationDomain::<F>::new(n).unwrap();
         let evals = self.as_evals(n);
         DensePolynomial::from_coefficients_vec(domain.ifft(&evals))
+    }
+
+    /// Returns the position of non-zero PI values.
+    pub fn get_pos(&self) -> Vec<usize> {
+        self.values.keys().cloned().collect()
+    }
+
+    // pub fn from_val_pos<T>(pos: Vec<usize>, vals: Vec<T>)
+    /// Some doc
+    pub fn from_val_pos<T>(pos: &[usize], vals: &[T]) -> Result<Self, Error>
+    where
+        T: ToConstraintField<F>,
+    {
+        let mut pi = Self::new();
+        pos.iter().zip_eq(vals).try_for_each(
+            |(p, v)| -> Result<(), Error> {
+                pi.add_input(*p, v)?;
+                Ok(())
+            },
+        )?;
+        Ok(pi)
     }
 }
 

--- a/plonk-core/src/proof_system/pi.rs
+++ b/plonk-core/src/proof_system/pi.rs
@@ -134,13 +134,13 @@ where
     }
 
     /// Returns the position of non-zero PI values.
-    pub fn get_pos(&self) -> Vec<usize> {
-        self.values.keys().cloned().collect()
+    pub fn get_pos(&self) -> impl Iterator<Item = &usize> {
+        self.values.keys()
     }
 
     /// Returns the non-zero PI values.
-    pub fn get_vals(&self) -> Vec<F> {
-        self.values.values().cloned().collect()
+    pub fn get_vals(&self) -> impl Iterator<Item = &F> {
+        self.values.values()
     }
 }
 

--- a/plonk-core/src/proof_system/pi.rs
+++ b/plonk-core/src/proof_system/pi.rs
@@ -75,8 +75,7 @@ where
     /// Inserts all the elements of `iter` converted into constraint field
     /// elements in consecutive positions.
     /// Returns the number of field elements occupied by `iter`
-    /// [`Error::InvalidPublicInputValue`] if the input could not be
-    /// converted.
+    /// [`Error::InvalidPublicInputValue`] if the input could not be converted.
     fn extend<'t, T, I>(
         &mut self,
         init_pos: usize,
@@ -116,13 +115,10 @@ where
         DensePolynomial::from_coefficients_vec(domain.ifft(&evals))
     }
 
-    /// Returns the position of non-zero PI values.
-    pub fn get_pos(&self) -> Vec<usize> {
-        self.values.keys().cloned().collect()
-    }
-
-    // pub fn from_val_pos<T>(pos: Vec<usize>, vals: Vec<T>)
-    /// Some doc
+    /// Constructs [`PublicInputs`] from a positions and a values.
+    ///
+    /// Panics if the positions and values have different lenghts or if
+    /// several values try to be inserted in the same position.
     pub fn from_val_pos<T>(pos: &[usize], vals: &[T]) -> Result<Self, Error>
     where
         T: ToConstraintField<F>,
@@ -135,6 +131,16 @@ where
             },
         )?;
         Ok(pi)
+    }
+
+    /// Returns the position of non-zero PI values.
+    pub fn get_pos(&self) -> Vec<usize> {
+        self.values.keys().cloned().collect()
+    }
+
+    /// Returns the non-zero PI values.
+    pub fn get_vals(&self) -> Vec<F> {
+        self.values.values().cloned().collect()
     }
 }
 


### PR DESCRIPTION
Changes included in the PR:
  - Add PI intended positions as output of `compile()`:
     Circuit compilation now outputs `ProverKey` and `VerifierKey` + a vector of the positions where public inputs were introduced
  - Constrain visibility of `insert()` as it is intended for internal use, `add_input()` should be used instead.
  - Add aux functions `get_pos()` `get_vals()` and `from_val_pos()` for working and constructing `PublicInputs` more easily.